### PR TITLE
Fixed 'We Are Titans' link in the Credits section of the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ timely fashion. If critical issues for a particular implementation exist at the
 time of a major release, support for that Ruby version may be dropped.
 
 ## Credits
-[We Are Titans](https://www.wearetitans.net).
+[We Are Titans](http://www.wearetitans.net).
 
 ## <a name="copyright"></a>Copyright
 Copyright (c) 2012 Code for America. See [LICENSE][] for details.


### PR DESCRIPTION
HTTPS wasn't working with the 'www' prefix, and without it there was an error with the security certificate.  I see no reason to use HTTPS here, so I changed the link to use HTTP.
