### PR TITLE
update all PDF links on government and citizen openimpact pages

### DIFF
--- a/app/views/pages/openimpact-citizen.html
+++ b/app/views/pages/openimpact-citizen.html
@@ -237,7 +237,7 @@
         <h2>Hackathons</h2>
         <p>Host a Hackathon. Hackathons promote collaboration between community members as well as city staff and city residents. They allows for discussion of civic issues, and are loads of fun.</p>
         <p>Invite friends, allied organizations, and government officials to your event and have them hack away at a civic issue. Successful hackathons are those who strive to bring together a diverse field of specialties and interests.</p>
-        <p>You can hack away at code (i.e make an app or API) or a policy (i.e. drafting an open data policy). <a href="http://codeforamerica.org/wp-content/uploads/2012/07/hackathon_steps_citizens.pdf">Follow these steps and launch your own hackathon</a>.</p>
+        <p>You can hack away at code (i.e make an app or API) or a policy (i.e. drafting an open data policy). <a href="https://www.dropbox.com/s/co5kq4sef12yhis/hackathon_steps_citizens.pdf?dl=1">Follow these steps and launch your own hackathon</a>.</p>
         <h2>City Camp</h2>
         <p>Organize a CityCamp. CityCamp is an unconference focused on innovation for municipal governments and community organizations. They have become widely popular as a way to bring different stakeholders together (i.e. designers, developers and city leaders) to discuss new ways of solving civic problems. Unconferences are not your typical conference, they are interactive and engaging. The participants play a huge role in directing the conference. Here is a <a href="http://citycamp.govfresh.com/start-a-camp/" target="_blank">breakdown</a> of how to get started.</p>
         <h2>Speaker Panel</h2>
@@ -285,7 +285,7 @@
                 <li>Follow-up on your email. Call your city councilor's office confirming
                     a time to meet.</li>
                 <p>Quick Tip: Call way in advance to the date you want!</p>
-                <li>At the meeting use the <a href="http://codeforamerica.org/wp-content/uploads/2012/07/deckscript.pdf">slideshow deck</a> (with the <a href="http://codeforamerica.org/wp-content/uploads/2012/07/deckscript.pdf">slideshow script</a>) and give your city council member the <a href="http://codeforamerica.org/wp-content/uploads/2012/07/handout_for_gov.pdf">open government handout</a>. Ask your city official to sign the <a href="http://brigade.codeforamerica.org/pages/openimpact-government" target="_blank">open government pledge</a>.</li>
+                <li>At the meeting use the <a href="https://www.dropbox.com/s/lz0b07jijnbsfxx/pptdeck.pdf?dl=1">slideshow deck</a> (with the <a href="https://www.dropbox.com/s/0acjjqf6f7vykfd/deckscript.pdf?dl=1">slideshow script</a>) and give your city council member the <a href="https://www.dropbox.com/s/3rg7ka7q959gx4u/handout_for_gov.pdf?dl=1">open government handout</a>. Ask your city official to sign the <a href="http://brigade.codeforamerica.org/pages/openimpact-government" target="_blank">open government pledge</a>.</li>
             </ol>
         </div>
         </div>
@@ -319,7 +319,7 @@
             <li>Deadlines to submit speaking requests vary</li>
             <li>Fill city hall with your supporters. The more people you arrive with, the bigger the statement to your elected officials.</li>
         </ul>
-        <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/speech_to_city_council.pdf">Click here for a sample speech and speaking tips!</a></p>
+        <p><a href="https://www.dropbox.com/s/h6w76abr3kruqu9/speech_to_city_council.pdf?dl=1">Click here for a sample speech and speaking tips!</a></p>
         </div>
     </section>
 
@@ -329,12 +329,12 @@
     </h1>
     <section class="rounded resources">
         <div class="section-inner">
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/handout_general.pdf">General Handout</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/handout_for_gov.pdf">Government Handout</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/speech_to_city_council.pdf">Speech to City Councils</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/pptdeck.pdf">Open Government Slideshow Deck</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/deckscript.pdf">Slideshow Deck Script</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/hackathon_steps_citizens.pdf">Hackathon Guide</a></p>
+            <p><a href="https://www.dropbox.com/s/694znr3b4qszeqd/handout_general.pdf?dl=1">General Handout</a></p>
+            <p><a href="https://www.dropbox.com/s/3rg7ka7q959gx4u/handout_for_gov.pdf?dl=1">Government Handout</a></p>
+            <p><a href="https://www.dropbox.com/s/h6w76abr3kruqu9/speech_to_city_council.pdf?dl=1">Speech to City Councils</a></p>
+            <p><a href="https://www.dropbox.com/s/lz0b07jijnbsfxx/pptdeck.pdf?dl=1">Open Government Slideshow Deck</a></p>
+            <p><a href="https://www.dropbox.com/s/0acjjqf6f7vykfd/deckscript.pdf?dl=1">Slideshow Deck Script</a></p>
+            <p><a href="https://www.dropbox.com/s/co5kq4sef12yhis/hackathon_steps_citizens.pdf?dl=1">Hackathon Guide</a></p>
         </div>
     </section>
 

--- a/app/views/pages/openimpact-government.html
+++ b/app/views/pages/openimpact-government.html
@@ -249,7 +249,7 @@
             <h3>CIVIC APP HACKATHON</h3>
 
             <p>Hackathons are events that bring people together across all disciplines, to develop solutions to civic challenges. Hacks can range from policy hacks to those that focus on developing technical apps. Get started planning your hackathon with our
-            <a href="http://codeforamerica.org/wp-content/uploads/2012/07/hackathon_steps_gov.pdf">tips on how to host a hackathon</a>, or learn from previously held events in
+            <a href="https://www.dropbox.com/s/jmg3fqig6vlryr6/hackathon_steps_gov.pdf?dl=1">tips on how to host a hackathon</a>, or learn from previously held events in
             <a href="http://www.prweb.com/releases/2012/3/prweb9263240.htm">Joplin</a>,
              <a href="http://www.tampagov.net/information_resources/HACKATHON/">Tampa</a>,
              <a href="http://storify.com/cindyroyal/code-for-america-hackathon-austin">Austin</a>.</p>
@@ -308,7 +308,7 @@
                         <a href="http://arvada.org/opendata/">arvada.org/opendata</a>). </p>
 
                     <p>When you’re ready to create your open data portal, follow
-                        <a href="http://codeforamerica.org/wp-content/uploads/2012/07/open_data_portal_steps.pdf">our six tips for creating an open data portal</a>.</p>
+                        <a href="https://www.dropbox.com/s/wi9bkpksd8r2g90/open_data_portal_steps.pdf?dl=1">our six tips for creating an open data portal</a>.</p>
         </div>
     </section>
 
@@ -415,11 +415,10 @@
 
     <section class="rounded resources">
         <div class="section-inner">
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/procurement_steps.pdf
-">Improving Procurement Guide</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/handout_for_gov.pdf">Open Government Handout</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/open_data_portal_steps.pdf">Open Data Portal Guide</a></p>
-            <p><a href="http://codeforamerica.org/wp-content/uploads/2012/07/hackathon_steps_gov.pdf">Guide to Hackathons</a></p>
+            <p><a href="https://www.dropbox.com/s/oo8hc2tyfp6xu1o/procurement_steps.pdf?dl=1">Improving Procurement Guide</a></p>
+            <p><a href="https://www.dropbox.com/s/3rg7ka7q959gx4u/handout_for_gov.pdf?dl=1">Open Government Handout</a></p>
+            <p><a href="https://www.dropbox.com/s/wi9bkpksd8r2g90/open_data_portal_steps.pdf?dl=1">Open Data Portal Guide</a></p>
+            <p><a href="https://www.dropbox.com/s/jmg3fqig6vlryr6/hackathon_steps_gov.pdf?dl=1">Guide to Hackathons</a></p>
         </div>
     </section>
 </div>


### PR DESCRIPTION
The PDFs were updated to make the "openimpact.us" URLs into proper URLs. Links were changed to Dropbox for easier updates in the future.
