### PR TITLE
add custom page titles for open impact pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
   <head>
     <script type="text/javascript">var _sf_startpt=(new Date()).getTime()</script>
-    <title>The Code for America Brigade | <%= controller.controller_name.titleize %></title>
+    <title>The Code for America Brigade | <%= @page_title || controller.controller_name.titleize %></title>
     <meta name="description" content="The Code for America Brigade connects passionate technologists in their communities to work together to deploy reusable civic apps.">
     <%= stylesheet_link_tag    'application', :media => 'all' %>
     <%= javascript_include_tag 'application' %>

--- a/app/views/pages/openimpact-citizen.html
+++ b/app/views/pages/openimpact-citizen.html
@@ -1,3 +1,4 @@
+<% @page_title='Open Impact | Citizen' %>
 <!-- TOP HEADER TITLE / OPENIMPACT LOGO -->
 <div class="row">
     <div class="span6">

--- a/app/views/pages/openimpact-government.html
+++ b/app/views/pages/openimpact-government.html
@@ -1,3 +1,4 @@
+<% @page_title='Open Impact | Government' %>
 <!-- TOP HEADER TITLE / OPENIMPACT LOGO -->
 <div class="row">
     <div class="span6">

--- a/app/views/pages/openimpact.html.erb
+++ b/app/views/pages/openimpact.html.erb
@@ -1,3 +1,4 @@
+<% @page_title='Open Impact | Landing' %>
 <div class="row">
   <div class="span12">
     <img src="/assets/openimpact/main_banner.png">


### PR DESCRIPTION
Current deploy has default titles for all pages which is bad for SEO and analytics. This branch adds a template variable for custom page titles.
