### PR TITLE
Text for link to CfA_Brigade_logo.jpg is incorrect

### DIFF
--- a/app/views/pages/tools.html.haml
+++ b/app/views/pages/tools.html.haml
@@ -25,6 +25,6 @@
 %p
   %a{:title => "png version", :href => "http://codeforamerica.org/wp-content/uploads/2012/01/CfA_Brigade_logo.png"} CfA_Brigade_logo.png
 %p
-  %a{:title => "jpg version", :href => "http://codeforamerica.org/wp-content/uploads/2012/01/CfA_Brigade_logo.jpg"} CfA_Brigade_logo.png
+  %a{:title => "jpg version", :href => "http://codeforamerica.org/wp-content/uploads/2012/01/CfA_Brigade_logo.jpg"} CfA_Brigade_logo.jpg
 %p
   %a{:title => "Code for America logos", :href => "http://codeforamerica.org/logos/"} Code for America logos


### PR DESCRIPTION
Two images for the Brigade logo are available for download at brigade.codeforamerica.org/pages/tools under the "Graphics" section. There are links to a PNG and a JPG version of the logo.

The text for these links both read "CfA_Brigade_logo.png". The text for the JPG one should read "CfA_Brigade_logo.jpg".
