### PR TITLE
The active element on navigation bar is solid instead of transparent

### DIFF
--- a/app/assets/stylesheets/navigation.css.scss
+++ b/app/assets/stylesheets/navigation.css.scss
@@ -57,7 +57,7 @@ header#top-deck {
 
         &.active a {
           color: #0072ac;
-          background: #fff;
+          background: rgba(255, 255, 255, 0);
           padding: 10px 10px 14px;
           @include border-radius(5px 5px 5px 5px);
         }


### PR DESCRIPTION
The navigation button for the page you're currently on has a solid (instead of transparent) background. This means that the "Home" button gets in the way of the background of the homepage when you're on it.

This pull request fixes this by changing the background of this element...

from this: `background: #fff;`
to this: `background: rgba(255, 255, 255, 0);`

Before-and-after pics below.

![before](https://f.cloud.github.com/assets/1596394/121148/a665910a-6d75-11e2-8f81-dbcfbb7b54b2.png)

![after](https://f.cloud.github.com/assets/1596394/121145/64799232-6d75-11e2-8fee-dcbed1a55821.png)
