### PR TITLE
Add a migration for the linkedin_url on User

### DIFF
--- a/db/migrate/20130326012223_add_linked_in_to_user.rb
+++ b/db/migrate/20130326012223_add_linked_in_to_user.rb
@@ -1,0 +1,5 @@
+class AddLinkedInToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :linkedin_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120503225247) do
+ActiveRecord::Schema.define(:version => 20130326012223) do
 
   create_table "applications", :force => true do |t|
     t.string "name"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(:version => 20120503225247) do
     t.string   "github_uid"
     t.string   "first_name"
     t.string   "last_name"
+    t.string   "linkedin_url"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true


### PR DESCRIPTION
Fixes #135 

Adds a migration for the `linkedin_url`.

Make sure you run `$heroku run rake db:migate` after you deploy
