### PR TITLE
Faster members page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,7 @@ class UsersController < ApplicationController
 
       @users = @search.results
     else
-      @users = User.all
+      @users = User.all(:include => :location)
     end
   end
 end


### PR DESCRIPTION
This is a band-aid fix for issue #152 .
The main problem is an N+1 query in the user index view. It calls for user.location in a loop causes some 1800 SELECT queries to be executed. My fix includes the user's locations in the UserController#index method.

This should definitely make the query faster, but it doesn't address the overall problem. The members page is kind of pointless right now. The biggest feature is probably the search bar and you have to wait for all the users to load. It may be a better solution just to have Kaminari paginate the users.
