### PR TITLE
Add rake db:seed to list of commands for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You'll also need to install Imagemagick
     cp config/database.yml.example config/database.yml
     rake db:create
     rake db:migrate
+    rake db:seed
 
 ## Usage
     bundle exec rake sunspot:solr:start


### PR DESCRIPTION
Pretty self-explanatory, but without the seed data, there's not much to look at when getting started.
