### PR TITLE
Hide the github sign-up link until #94 is fixed. 

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -17,6 +17,10 @@
     <% end %>
     <%= form.input :password, input_html: {class: 'span5'} if @user.password_required? %>
     <%= form.submit 'Sign up', class: 'btn-large btn' %>
-  <%end%>
+    <!--
+    or
+    <%= link_to "Sign up with Github", user_omniauth_authorize_path(:github), class: 'btn-large btn-info' unless @user.github_uid.present? %>
+    -->
+ <%end%>
 
 </div>


### PR DESCRIPTION
I don't have the rails skills to figure out what's wrong in issue #94, but @kmcurry noted that the link should be hidden until it's fixed. 
