### PR TITLE
Sunspot needs to be running before running rake db:seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ You'll also need to install Imagemagick
     cd brigade
     bundle install
     cp config/database.yml.example config/database.yml
+    bundle exec rake sunspot:solr:start
     rake db:create
     rake db:migrate
     rake db:seed
 
 ## Usage
-    bundle exec rake sunspot:solr:start
     rails server
 
 


### PR DESCRIPTION
The Solr indexing on the User model requires Sunspot to be running before seeding; otherwise you'll get a connection refused error.
