### PR TITLE
added js to close flash partial on click of x - issue #163

### DIFF
--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <section id="flash">
   <div class="content no-padding">
     <%=raw message %>
-    <%= link_to_function "x", "document.getElementByClassName('close-now').fade_out", class: "close-now", class: "icon" %>
+    <%= link_to_function "x", "document.getElementByClassName('close-now').fade_out", class: "close-now icon" %>
   </div>
 </section>


### PR DESCRIPTION
I couldn't find any refs to 'close-now' outside the css, so looks like logic to close the flash div was never created.  I added some.  It doesn't seem like it warrants a test, but slap my hand if you feel otherwise.  This should resolve issue #163.
