### PR TITLE
Add project monitor

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 import re
 from requests import get, post
 from operator import itemgetter
+from urlparse import urlparse
 
 from datetime import datetime
 from base64 import b64encode
@@ -59,6 +60,19 @@ def is_existing_organization(orgid):
     got = get("https://www.codeforamerica.org/api/organizations.geojson").json()
     orgids = [org["properties"]["id"] for org in got["features"]]
     return orgid in orgids
+
+
+# Load load projects from the cfapi
+def get_projects(projects, url, limit=10):
+    got = get(url)
+    new_projects = got.json()["objects"]
+    projects = projects + new_projects
+    if limit:
+        if len(projects) >= limit:
+            return projects
+    if "next" in got.json()["pages"]:
+        projects = get_projects(projects, got.json()["pages"]["next"], limit)
+    return projects
 
 
 # ROUTES
@@ -605,6 +619,30 @@ def post_test_checkin(brigadeid=None):
 
     else:
         return make_response(json.dumps(test_checkin_data), 200)
+
+
+@app.route('/brigade/projects/monitor')
+@app.route('/brigade/<brigadeid>/projects/monitor')
+def project_monitor(brigadeid=None):
+    ''' Check for Brigade projects on Travis'''
+    limit = int(request.args.get('limit',50))
+    travis_projects = []
+    projects = []
+    if not brigadeid:
+        projects = get_projects(projects, "https://www.codeforamerica.org/api/projects", limit)
+    else:
+        projects = get_projects(projects, "https://www.codeforamerica.org/api/organizations/"+brigadeid+"/projects", limit)
+
+    # Loop through projects and get
+    for project in projects:
+        if project["code_url"]:
+            url = urlparse(project["code_url"])
+            if url.netloc == "github.com":
+                travis_url = "https://api.travis-ci.org/repositories"+url.path+"/builds"
+                project["travis_url"] = travis_url
+                travis_projects.append(project)
+
+    return render_template('projectmonitor.html', projects=travis_projects, org_name=brigadeid)
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -329,17 +329,6 @@ def projects(brigadeid=None):
         else:
             next = "/brigade/projects/?page=2"
 
-    def get_projects(projects, url, limit=10):
-        got = get(url)
-        new_projects = got.json()["objects"]
-        projects = projects + new_projects
-        if limit:
-            if len(projects) >= limit:
-                return projects
-        if "next" in got.json()["pages"]:
-            projects = get_projects(projects, got.json()["pages"]["next"], limit)
-        return projects
-
     if brigadeid:
         url = "https://www.codeforamerica.org/api/organizations/"+ brigadeid +"/projects"
         if search or sort_by or page:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -142,3 +142,16 @@ h2 {
   color: white;
   margin: 0px;
 }
+
+/* Project Monitor */
+#projects a:link, #projects a:visited, #projects a:hover, #projects a:focus, #projects a:active {
+  color: #5a5a5a;
+}
+
+.alert-success, .alert-failure {
+  border: 0px;
+}
+
+.project {
+  padding: 15px;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -144,7 +144,7 @@ h2 {
 }
 
 /* Project Monitor */
-#projects a:link, #projects a:visited, #projects a:hover, #projects a:focus, #projects a:active {
+#monitor a:link, #monitor a:visited, #monitor a:hover, #monitor a:focus, #monitor a:active {
   color: #5a5a5a;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -144,6 +144,10 @@ h2 {
 }
 
 /* Project Monitor */
+#monitor {
+  min-height: 700px;
+}
+
 #monitor a:link, #monitor a:visited, #monitor a:hover, #monitor a:focus, #monitor a:active {
   color: #5a5a5a;
 }

--- a/templates/brigade.html
+++ b/templates/brigade.html
@@ -22,6 +22,7 @@
           <a href=".#issues" class="button">Open Issues</a>
           <a href="./attendance" class="button">Attendance</a>
           <a href="./checkin" class="button">Check In</a>
+          <a href="./projects/monitor" class="button">Project Monitor</a>
       </div>
     </div>
 

--- a/templates/projectmonitor.html
+++ b/templates/projectmonitor.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <div class="layout-semibreve layout-centered">
+
+  {% if org_name %}
+  <h1>{{org_name}}'s Project Monitor</h1>
+  {% else %}
+  <h1>The Civic Tech Movement Project Monitor</h1>
+  {% endif %}
+
+  <ul id="projects">
+  </ul>
+
+</div>
+
+{% endblock %}
+
+{% block js %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
+
+<script>
+
+$( document ).ready(function() {
+
+  function getProject(project){
+
+    if (project.code_url) {
+
+      if (project.code_url.indexOf('github.com') > -1) {
+
+        repo = project.code_url.replace("https://github.com/","");
+
+        travis_url = 'https://api.travis-ci.org/repositories/' + repo + '/builds'
+
+        $.getJSON(travis_url, function(response){
+
+          if (response[0]) {
+
+            project.when = moment(new Date(project.last_updated)).fromNow()
+
+            if (response[0].result == 0){
+              project.state = "alert-success"
+            } else {
+              project.state = "alert-failure"
+            }
+
+            repo = project.code_url.replace("https://github.com/","");
+            project.travis = 'https://travis-ci.org/' + repo + '/builds/' + response[0].id
+
+            html = '<li class="'+project.state+' layout-centered layout-crotchet"> \
+              <div class="project"> \
+                <h2> <a href="'+project.code_url+'">'+project.name+'</a> </h2> \
+                <hr /> \
+                <a class="icon-tools" href="'+project.travis+'"> Built '+project.when+' ago </a> \
+              </div> \
+            </li>'
+
+            $("#projects").append(html);
+
+          }
+
+        });
+
+      }
+
+    }
+
+  }
+
+
+  var projects = {{ projects | tojson }};
+
+  $.each(projects, function(i, project){
+
+    getProject(project);
+
+  });
+
+});
+
+</script>
+
+{% endblock %}

--- a/templates/projectmonitor.html
+++ b/templates/projectmonitor.html
@@ -2,18 +2,20 @@
 
 {% block content %}
 
-  <div class="layout-semibreve layout-centered">
+<section class="slab-dark-blue">
+  <div id="monitor" class="layout-breve layout-centered">
 
-  {% if org_name %}
-  <h1>{{org_name}}'s Project Monitor</h1>
-  {% else %}
-  <h1>The Civic Tech Movement Project Monitor</h1>
-  {% endif %}
+    {% if org_name %}
+    <h1>{{org_name}}'s Project Monitor</h1>
+    {% else %}
+    <h1>The Civic Tech Movement Project Monitor</h1>
+    {% endif %}
 
-  <ul id="projects">
-  </ul>
+    <ul id="projects">
+    </ul>
 
-</div>
+  </div>
+</section>
 
 {% endblock %}
 


### PR DESCRIPTION
Adds a new project monitor to the Brigade site. The intent is to replace the current http://project-monitor.codeforamerica.org/ with a simpler version that works for all the Brigades as well.

This service goes through all the projects for a Brigade and checks travis-ci for any builds. If the project uses travis, then it will show up on this dashboard.

The urls are:
https://www.codeforamerica.org/brigade/projects/monitor
https://www.codeforameria.org/brigade/Code-for-America/projects/monitor