### PR TITLE
Stages use status now instead of search

### DIFF
--- a/README-Project-Search.md
+++ b/README-Project-Search.md
@@ -1,5 +1,4 @@
-# A guide about Project Search and civic.json
-
+# A guide to Project Search and the civic.json
 
 ## Project Search
 The [Project Search](http://www.codeforamerica.org/brigade/projects) page is a new service we built to search across [thousands](http://www.codeforamerica.org/brigade/numbers/) of civic technology projects. Go try it out, we think its pretty useful.
@@ -7,14 +6,16 @@ The [Project Search](http://www.codeforamerica.org/brigade/projects) page is a n
 #### How to search
 You can search by using the search bar or using the [q=bicycles](http://www.codeforamerica.org/brigade/projects?q=bicycles) parameter. You'll see the url of the site update to show your search. This is an exact match of the [cfapi search](http://www.codeforamerica.org/api/projects?q=bicycles).
 
-Your search will try and match against the project's `name`, `description`, `status`, `tags`, `languages`, and `organization_name` such as "Code for San Francisco".
+Your search will try and match against the project's `name`, `description`, `tags`, `languages`, and `organization_name` such as "Code for San Francisco".
 
-You can also filter types of organizations. This done by adding the parameter [organization_type=Brigade](http://www.codeforamerica.org/brigade/projects?organization_type=Brigade). The options are `Brigade`, `Code for All`, `Government`. Code for America's projects are included under Code for All.
+There are two types of filters. Status which is [explained below](#stages) and organization type. This done by adding the parameter [organization_type=Brigade](http://www.codeforamerica.org/brigade/projects?organization_type=Brigade). The options are `Brigade`, `Code for All`, `Government`. Code for America's projects are included under Code for All.
 
 By default, the returns projects in order of most recently updated. When searching, it returns in order of most relevant.
 
 #### Stages
-You’ll notice that many projects have a Project Stage. These stages are [explained in detail](http://www.codeforamerica.org/brigade/projects/stages) and are meant to give some context to this big pile of projects. If you are government employee looking for [a tool to help find preschools](http://www.codeforamerica.org/brigade/projects?q=official,%20preschool), you’ll probably only want to see finished `Official` projects. If you are a Brigade leader looking for [transit data projects](http://www.codeforamerica.org/brigade/projects?q=Experiment,%20transit%20data) for your volunteers to hack on, you’ll want to find `Alpha` and `Experiment` projects that still need contributors. Get it?
+You’ll notice that many projects have a Project Stage. These stages are [explained in detail](http://www.codeforamerica.org/brigade/projects/stages) and are meant to give some context to how complete the project is. If you are government employee looking for [a tool to help find preschools](http://www.codeforamerica.org/brigade/projects?status=Official&q=preschool), you’ll probably only want to see finished `status=Official` projects. If you are a Brigade leader looking for [transit data projects](http://www.codeforamerica.org/brigade/projects?status=Experimentq=transit%20data) for your volunteers to hack on, you’ll want to find `status=Alpha` and `status=Experiment` projects that still need contributors. Get it?
+
+We call them project stages but in the civic.json they are called status. Sorry if its confusing. The valid status that we are using are `Experiment`, `Alpha`, `Beta`, and `Official`.
 
 #### Tags
 The Project Search searches from a bunch of attributes about the project, yet sometimes the right term just isn’t in there. Thats where tags come in. Tags are a great catchall place to put metadata about the project. `transit, buses, open data, iOS, California` are examples of the random things people might want to search for and find for a specific project. We’ll keep watching what tags are being used and what people are searching for to produce a recommended list.

--- a/README-Project-Search.md
+++ b/README-Project-Search.md
@@ -4,24 +4,24 @@
 The [Project Search](http://www.codeforamerica.org/brigade/projects) page is a new service we built to search across [thousands](http://www.codeforamerica.org/brigade/numbers/) of civic technology projects. Go try it out, we think its pretty useful.
 
 #### How to search
-You can search by using the search bar or using the [q=bicycles](http://www.codeforamerica.org/brigade/projects?q=bicycles) parameter. You'll see the url of the site update to show your search. This is an exact match of the [cfapi search](http://www.codeforamerica.org/api/projects?q=bicycles).
+You can search by using the search bar or using the `q` parameter like so: [q=bicycles](http://www.codeforamerica.org/brigade/projects?q=bicycles). When you submit a query, you'll see the url of the site update to show your search. This is an exact match to the [cfapi search](http://www.codeforamerica.org/api/projects?q=bicycles).
 
-Your search will try and match against the project's `name`, `description`, `tags`, `languages`, and `organization_name` such as "Code for San Francisco".
+Your search will match against the project's `name`, `description`, `tags`, `languages`, and `organization_name`.
 
-There are two types of filters. Status which is [explained below](#stages) and organization type. This done by adding the parameter [organization_type=Brigade](http://www.codeforamerica.org/brigade/projects?organization_type=Brigade). The options are `Brigade`, `Code for All`, `Government`. Code for America's projects are included under Code for All.
+In addition, you can filter by project `status`, [explained below](#stages), and by the `type` of a project's organization. Search for organization type by adding the `organization_type` parameter like so: [organization_type=Brigade](http://www.codeforamerica.org/brigade/projects?organization_type=Brigade). The options are `Brigade`, `Code for All`, `Government`. Code for America's projects are included under Code for All.
 
-By default, the returns projects in order of most recently updated. When searching, it returns in order of most relevant.
+By default, projects are listed in order of most recently updated. When searching, results are listed in order of most relevant.
 
 #### Stages
-You’ll notice that many projects have a Project Stage. These stages are [explained in detail](http://www.codeforamerica.org/brigade/projects/stages) and are meant to give some context to how complete the project is. If you are government employee looking for [a tool to help find preschools](http://www.codeforamerica.org/brigade/projects?status=Official&q=preschool), you’ll probably only want to see finished `status=Official` projects. If you are a Brigade leader looking for [transit data projects](http://www.codeforamerica.org/brigade/projects?status=Experimentq=transit%20data) for your volunteers to hack on, you’ll want to find `status=Alpha` and `status=Experiment` projects that still need contributors. Get it?
+You'll notice that many projects have a Project Stage. These stages are [explained in detail here](http://www.codeforamerica.org/brigade/projects/stages), and are meant to give some context to how complete a project is. If you are government employee looking for [a tool to help find preschools](http://www.codeforamerica.org/brigade/projects?status=Official&q=preschool), you'll probably only want to see finished, `status=Official`, projects. If you are a Brigade leader looking for [transit data projects](http://www.codeforamerica.org/brigade/projects?status=Experimentq=transit%20data) for your volunteers to hack on, you'll want to find `status=Alpha` and `status=Experiment` projects that still need contributors. Get it?
 
-We call them project stages but in the civic.json they are called status. Sorry if its confusing. The valid status that we are using are `Experiment`, `Alpha`, `Beta`, and `Official`.
+We call them project stages but in the civic.json they are called status. Sorry if it's confusing. The valid statuses that we are using are `Experiment`, `Alpha`, `Beta`, and `Official`.
 
 #### Tags
-The Project Search searches from a bunch of attributes about the project, yet sometimes the right term just isn’t in there. Thats where tags come in. Tags are a great catchall place to put metadata about the project. `transit, buses, open data, iOS, California` are examples of the random things people might want to search for and find for a specific project. We’ll keep watching what tags are being used and what people are searching for to produce a recommended list.
+The Project Search queries a bunch of attributes about a project, yet sometimes the right term just isn't in there. Thats where tags come in. Tags are a great catchall place to put metadata about a project. `transit, buses, open data, iOS, California` are examples of the random things people might want to search for and find for a specific project. We'll keep watching what tags are being used and what people are searching for to produce a recommended list.
 
 ## Civic.json
-To add this metadata about stages and tags to the project, we’re including a civic.json file in each project. The idea of a civic.json comes from [Beta.NYC](https://github.com/BetaNYC/civic.json) and [Chi Hack Night](https://github.com/open-city/civic-json-worker). In the Code for America version of the idea, we’re only including two attributes, `status` and `tags`. You can include other data in there, yet you won’t find it on the Project Search page yet.
+To add this metadata about stages and tags to the project, we recommend including a civic.json file in each project's repo. The civic.json concept comes from [Beta.NYC](https://github.com/BetaNYC/civic.json) and [Chi Hack Night](https://github.com/open-city/civic-json-worker). In the Code for America implementation of the idea, we're only expecting to find two attributes: `status` and `tags`. You can include other data in the file, but you won't find it on the Project Search page yet.
 
 Include the civic.json file at the top level of your project.
 
@@ -38,22 +38,23 @@ Include the civic.json file at the top level of your project.
     ]
 }
 ```
+
 #### Adding a civic.json to your project
-To add these important stages and tags to your project, you can use the form we built into the project search page. If your project doesn’t have civic.json file yet, you’ll see a button to add one.
+To add these important stages and tags to your project, you can use the form that we've built into the project search page. If your project doesn't have a civic.json file yet, you'll see a button to add one.
 
 ![add a civic.json file](http://i.imgur.com/lhQ7GIL.png)
 
-The url for the form follows the pattern of `http://www.codeforamerica.org/brigade/<Brigade-Name>/projects/<project-name>/add-civic-json`. An [example](http://www.codeforamerica.org/brigade/Code-for-America/projects/brigade/add-civic-json).
+The url for the form follows the pattern of `http://www.codeforamerica.org/brigade/<Brigade-Name>/projects/<project-name>/add-civic-json`. [For example](http://www.codeforamerica.org/brigade/Code-for-America/projects/brigade/add-civic-json).
 
-You'll need to log into Github. Once you fill out the form, it will send a Pull Request from your Github account to the project for their approval or rejection.
+You'll need to log into Github. When you fill out and submit the form, it will send a Pull Request from your Github account to the project for their approval or rejection.
 
-If you are having trouble, you can always build your own civic.json and add it to the top level of the project.
+If you are having trouble with the form, you can always create your own civic.json file and add it to the top level of the project repo.
 
 ## Advice for Brigades
-We recommend that your Delivery Lead or Captain take time to once a month to review each of your group’s projects and update the metadata about it. 
+We recommend that your Delivery Lead or Captain take time to once a month to review each of your group's projects and update the metadata about it.
 
 #### Why?
-The Project Search page is already really popular and is becoming the main way other Brigades find out about your group’s work. Its important to keep your Brigade's projects info up to date because:
+The Project Search page is already really popular and is becoming the main way other Brigades find out about your group's work. It's important to keep your Brigade's project info up to date because:
 * Project Search is how civic hackers across the country will find projects to contribute to.
 * Project Search is how city employees will find projects to solve problems in their cities.
 * Code for America will give different types of support to different project stages.
@@ -63,5 +64,5 @@ The Project Search page is already really popular and is becoming the main way o
 1. Go to your Brigade's list of projects. You can just search for your group like [http://www.codeforamerica.org/brigade/projects?q=Code+for+San+Francisco](http://www.codeforamerica.org/brigade/projects?q=Code+for+San+Francisco) or go to your Brigade's individual project page like [https://www.codeforamerica.org/brigade/Code-for-San-Francisco/projects](https://www.codeforamerica.org/brigade/Code-for-San-Francisco/projects).
 2. Review each project. Talk to the project team, check out their live examples, their README.
 3. Choose the appropriate [project stage](http://www.codeforamerica.org/brigade/projects/stages). 
-4. Choose the appropriate tags. Our initial list of what looks useful is search terms, city name, and tech stack.
-5. Make the civic.json file. You can [use our form](#adding-a-civicjson-to-your-project) or edit the civic.json file direct on Github.
+4. Choose appropriate tags: Your city name, tech stack details; any term that someone might use to search for or categorize your project.
+5. Make the civic.json file. You can [use our form](#adding-a-civicjson-to-your-project) or create and edit a civic.json file directly on Github.

--- a/README-Project-Search.md
+++ b/README-Project-Search.md
@@ -1,7 +1,7 @@
 # A guide to Project Search and the civic.json
 
 ## Project Search
-The [Project Search](http://www.codeforamerica.org/brigade/projects) page is a new service we built to search across [thousands](http://www.codeforamerica.org/brigade/numbers/) of civic technology projects. Go try it out, we think its pretty useful.
+The [Project Search](http://www.codeforamerica.org/brigade/projects) page is a new service we built to search across [thousands](http://www.codeforamerica.org/brigade/numbers/) of civic technology projects. Go try it out, we think it's pretty useful.
 
 #### How to search
 You can search by using the search bar or using the `q` parameter like so: [q=bicycles](http://www.codeforamerica.org/brigade/projects?q=bicycles). When you submit a query, you'll see the url of the site update to show your search. This is an exact match to the [cfapi search](http://www.codeforamerica.org/api/projects?q=bicycles).
@@ -18,12 +18,12 @@ You'll notice that many projects have a Project Stage. These stages are [explain
 We call them project stages but in the civic.json they are called status. Sorry if it's confusing. The valid statuses that we are using are `Experiment`, `Alpha`, `Beta`, and `Official`.
 
 #### Tags
-The Project Search queries a bunch of attributes about a project, yet sometimes the right term just isn't in there. Thats where tags come in. Tags are a great catchall place to put metadata about a project. `transit, buses, open data, iOS, California` are examples of the random things people might want to search for and find for a specific project. We'll keep watching what tags are being used and what people are searching for to produce a recommended list.
+The Project Search queries a bunch of attributes about a project, but sometimes the right term just isn't in there. That's where tags come in. Tags are a great catchall place to put metadata about a project. `transit, buses, open data, iOS, California` are examples of the random things people might want to search for and find for a specific project. We'll keep watching what tags are being used and what people are searching for to produce a recommended list.
 
 ## Civic.json
-To add this metadata about stages and tags to the project, we recommend including a civic.json file in each project's repo. The civic.json concept comes from [Beta.NYC](https://github.com/BetaNYC/civic.json) and [Chi Hack Night](https://github.com/open-city/civic-json-worker). In the Code for America implementation of the idea, we're only expecting to find two attributes: `status` and `tags`. You can include other data in the file, but you won't find it on the Project Search page yet.
+To add this metadata about stages and tags to the project, we recommend including a `civic.json` file in each project's repo. The civic.json concept comes from [Beta.NYC](https://github.com/BetaNYC/civic.json) and [Chi Hack Night](https://github.com/open-city/civic-json-worker). In the Code for America implementation of the idea, we're only expecting to find two attributes: `status` and `tags`. You can include other data in the file, but you won't see it displayed on the Project Search page.
 
-Include the civic.json file at the top level of your project.
+Include the civic.json file at the top level of your project's repo.
 
 #### Example
 ```
@@ -40,11 +40,11 @@ Include the civic.json file at the top level of your project.
 ```
 
 #### Adding a civic.json to your project
-To add these important stages and tags to your project, you can use the form that we've built into the project search page. If your project doesn't have a civic.json file yet, you'll see a button to add one.
+To add these important stages and tags to your project, you can use the form that we've built into the project search page. If your project doesn't have a civic.json file yet, you'll see a button like this:
 
 ![add a civic.json file](http://i.imgur.com/lhQ7GIL.png)
 
-The url for the form follows the pattern of `http://www.codeforamerica.org/brigade/<Brigade-Name>/projects/<project-name>/add-civic-json`. [For example](http://www.codeforamerica.org/brigade/Code-for-America/projects/brigade/add-civic-json).
+The url for the form follows the pattern of `http://www.codeforamerica.org/brigade/<Brigade-Name>/projects/<project-name>/add-civic-json`. For example: [http://www.codeforamerica.org/brigade/Code-for-America/projects/brigade/add-civic-json](http://www.codeforamerica.org/brigade/Code-for-America/projects/brigade/add-civic-json).
 
 You'll need to log into Github. When you fill out and submit the form, it will send a Pull Request from your Github account to the project for their approval or rejection.
 

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -125,7 +125,7 @@
       {% if not projects %}
         <h2>Nothing here yet ... </h2>
       {% else %}
-        <p style="float:right;"><a id="more-projects" href="{{next}}{% if request.args.get('q') %}&q={{ request.args.get('q') }}{% endif %}" class="button">More Projects</a></p>
+        <p style="float:right;"><a id="more-projects" href="{{next}}{% if request.args.get('status') %}&status={{ request.args.get('status') }}{% endif %}{% if request.args.get('q') %}&q={{ request.args.get('q') }}{% endif %}" class="button">More Projects</a></p>
       {% endif %}
 
     </div> <!-- layout-breve -->

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -22,17 +22,18 @@
 
       <form id="project-search" action="{{ request.path }}" method="get">
         <p class="field">
-          <input id="project-search-bar" type="search" name="q" {% if request.args.get('q') %} value="{{ request.args.get('q') }}" {% endif %} role="search" placeholder="Schools javascript" /><button type="submit" class="button"><i class="icon-search"></i></button
+          <input id="project-search-bar" type="search" name="q" {% if request.args.get('q') %} value="{{ request.args.get('q') }}" {% endif %} role="search" placeholder="Schools javascript" /><button type="submit" class="button"><i class="icon-search"></i></button>
         </p>
+
       </form>
 
       <ul class="list-inline list-no-bullets">
         <h3>Project Stages</h3>
         <!-- <li><a href="?q=featured" id="Featured" class="button">Featured</a></li> -->
-        <li><a href="?q=Official" id="Official" class="button">Official</a></li>
-        <li><a href="?q=Beta" id="Beta" class="button">Beta</a></li>
-        <li><a href="?q=Alpha" id="Alpha" class="button">Alpha</a></li>
-        <li><a href="?q=Experiment" id="Experiment" class="button">Experiment</a></li>
+        <li><a href="?status=Official" id="Official" class="button">Official</a></li>
+        <li><a href="?status=Beta" id="Beta" class="button">Beta</a></li>
+        <li><a href="?status=Alpha" id="Alpha" class="button">Alpha</a></li>
+        <li><a href="?status=Experiment" id="Experiment" class="button">Experiment</a></li>
         <small><a href="/brigade/projects/stages">What are these?</a></small>
       </ul>
 
@@ -148,6 +149,9 @@ $('#projects').masonry({
 <script>
   {% if request.args.get('q') %}
   ga('send', 'event', 'Project Search', 'search', "{{ request.args.get('q') }}", 1 );
+  {% endif %}
+  {% if request.args.get('status') %}
+  ga('send', 'event', 'Project Search', 'search', "{{ request.args.get('status') }}", 1 );
   {% endif %}
 </script>
 

--- a/brigade/templates/stages.html
+++ b/brigade/templates/stages.html
@@ -56,7 +56,7 @@
 
 <div class="stage layout-semibreve" id="experiment">
   <h1><a href="#experiment" class="purple">Experiment</a></h1>
-  <a href="https://www.codeforamerica.org/brigade/projects?q=Experiment">Search for Experimental projects</a>
+  <a href="https://www.codeforamerica.org/brigade/projects?status=Experiment">Search for Experimental projects</a>
   <p>Experiments are explorations into a civic problem. They involve lots of research, lots of listening to local experts, and lots of throw-away code. Almost every project should start out as an experiment and most projects should probably stay as experiments.</p>
 
   <div class="layout-minim">
@@ -111,7 +111,7 @@
 <div class="stage layout-semibreve" id="alpha">
 
   <h1><a href="#alpha" class="light-blue">Alpha</a></h1>
-  <a href="https://www.codeforamerica.org/brigade/projects?q=Alpha">Search for Alpha projects</a>
+  <a href="https://www.codeforamerica.org/brigade/projects?status=Alpha">Search for Alpha projects</a>
   <p>Alpha projects have shown that with a little bit of work, they may be able to actually solve one persons problem. We also got some recommendations that are helpful for volunteer built projects as well as some cool infrastructure to get you help building your projects.</p>
 
   <div class="layout-minim">
@@ -171,7 +171,7 @@
 <div class="stage layout-semibreve" id="beta">
 
   <h1><a href="#beta" class="dark-blue">Beta</a></h1>
-  <a href="https://www.codeforamerica.org/brigade/projects?q=Beta">Search for Beta projects</a>
+  <a href="https://www.codeforamerica.org/brigade/projects?status=Beta">Search for Beta projects</a>
   <p>Beta projects are stable enough for a government partner to start putting their reputation behind it. A beta project should be useful for lots of people in your city with the beginnings of some proof of that usefulness. This proof will help get more users, get partners, and keep volunteers motivated to continue volunteering.</p>
 
   <div class="layout-minim">
@@ -224,7 +224,7 @@
 <div class="stage layout-semibreve" id="official">
 
   <h1><a href="#official" class="teal">Official</a></h1>
-  <a href="https://www.codeforamerica.org/brigade/projects?q=Official">Search for Official projects</a>
+  <a href="https://www.codeforamerica.org/brigade/projects?status=Official">Search for Official projects</a>
   <p>You did it! Official projects are what governments all across the country are going to be looking at. It should be polished up and ready for all those critical eyes. For real though, congratulations. Building impactful civic tech in your volunteer time is tough, lets party!</p>
 
   <div class="layout-minim">

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -521,6 +521,7 @@ def projects(brigadeid=None):
     sort_by = request.args.get("sort_by", None)
     page = request.args.get("page", None)
     organization_type = request.args.get("organization_type", None)
+    status = request.args.get("status", None)
 
     # Set next
     if page:
@@ -544,7 +545,7 @@ def projects(brigadeid=None):
             brigade = {"name": brigadeid.replace("-", " ")}
     else:
         url = "https://www.codeforamerica.org/api/projects"
-    if search or sort_by or page or organization_type:
+    if search or sort_by or page or organization_type or status:
         url += "?"
     if search:
         url += "&q=" + search
@@ -554,6 +555,8 @@ def projects(brigadeid=None):
         url += "&page=" + page
     if organization_type:
         url += "&organization_type=" + organization_type
+    if status:
+        url += "&status=" + status
 
     projects = get_projects(projects, url)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -259,6 +259,29 @@ class BrigadeTests(unittest.TestCase):
                     "default_branch" : "master"
                     } ''')
 
+        if "q=TEST" in url.geturl() or "organization_type=Brigade" in url.geturl() or "status=Alpha" in url.geturl():
+            return response(200, '''{
+                  "objects": [
+                    {
+                      "code_url": "TEST URL",
+                      "description": "TEST DESCRIPTION",
+                      "link_url": "TEST URL",
+                      "last_updated": "Mon, 10 Aug 2015 23:22:40 GMT",
+                      "name": "TEST PROJECT",
+                      "github_details" : {},
+                      "organization": {
+                        "id": "Code-for-San-Francisco",
+                        "name": "Code for San Francisco"
+                      },
+                      "organization_name": "Code for San Francisco",
+                      "status": "Alpha",
+                      "tags": "housing, ndoch, active"
+                    }
+                  ],
+                  "total" : 1,
+                  "pages": {}
+                } ''')
+
         raise ValueError('response_content: bad {} to "{}"'.format(request.method, url.geturl()))
 
     def test_signup(self):
@@ -390,6 +413,24 @@ class BrigadeTests(unittest.TestCase):
             card_head_div = soup.find('div', {'class': 'card-head Alpha'})
             self.assertIsNotNone(card_head_div)
             self.assertEqual(u'Alpha', card_head_div.text.strip())
+
+    def test_projects_searches(self):
+        ''' Test the different project searches '''
+        with HTTMock(self.response_content):
+            response = self.client.get("/brigade/projects?q=TEST")
+            soup = BeautifulSoup(response.data, "html.parser")
+            project_name = soup.find_all('h3')
+            self.assertEqual(u"TEST PROJECT", project_name[1].text.strip())
+
+            response = self.client.get("/brigade/projects?organization_type=Brigade")
+            soup = BeautifulSoup(response.data, "html.parser")
+            project_name = soup.find_all('h3')
+            self.assertEqual(u"TEST PROJECT", project_name[1].text.strip())
+
+            response = self.client.get("/brigade/projects?status=Alpha")
+            soup = BeautifulSoup(response.data, "html.parser")
+            project_name = soup.find_all('h3')
+            self.assertEqual(u"TEST PROJECT", project_name[1].text.strip())
 
     def test_project_monitor(self):
         ''' Test the project monitor page works as expected '''


### PR DESCRIPTION
The linked stages will now use the `status` parameter instead of the `q` search param. This more exactly matches the cfapi and also returns projects with a stage in order of last_updated. Very nice. I included tests but they are just testing mock responses, not the cfapi, which is of questionable utility.

@tmaybe want to review?