### PR TITLE
Project monitor ui

### DIFF
--- a/brigade/static/css/style.css
+++ b/brigade/static/css/style.css
@@ -176,6 +176,7 @@ input[type="text"],input[type="email"],input[type="password"],input[type="search
 .project {
   display: table-cell;
   float: none;
+  padding-bottom: 8px;
 }
 
 .project h2 {

--- a/brigade/static/css/style.css
+++ b/brigade/static/css/style.css
@@ -166,6 +166,17 @@ input[type="text"],input[type="email"],input[type="password"],input[type="search
   color: #5a5a5a;
 }
 
+.row {
+  display: table;
+  border-spacing: 15px 5px;
+  width: 100%;
+}
+
+.project {
+  display: table-cell;
+  float: none;
+}
+
 .alert-success, .alert-failure {
   border: 0px;
 }
@@ -257,7 +268,7 @@ thead th {
 }
 
 td {
-  text-align:center; 
+  text-align:center;
   vertical-align:middle;
 }
 

--- a/brigade/static/css/style.css
+++ b/brigade/static/css/style.css
@@ -170,11 +170,18 @@ input[type="text"],input[type="email"],input[type="password"],input[type="search
   display: table;
   border-spacing: 15px 5px;
   width: 100%;
+  display: none;
 }
 
 .project {
   display: table-cell;
   float: none;
+}
+
+.project h2 {
+  padding-top: 14px;
+  padding-left: 14px;
+  padding-right: 14px;
 }
 
 .alert-success, .alert-failure {

--- a/brigade/templates/projectmonitor.html
+++ b/brigade/templates/projectmonitor.html
@@ -37,7 +37,6 @@ $( document ).ready(function() {
         travis_url = 'https://api.travis-ci.org/repositories/' + repo + '/builds'
 
         $.getJSON(travis_url, function(response){
-
           if (response[0]) {
 
             project.when = moment(new Date(project.last_updated)).fromNow()
@@ -50,19 +49,21 @@ $( document ).ready(function() {
 
             repo = project.code_url.replace("https://github.com/","");
             project.travis = 'https://travis-ci.org/' + repo + '/builds/' + response[0].id
+            var projectsLength = $('#projects').find('.row').children('.project').length;
+            console.log(projectsLength);
+            if (projectsLength === 0 || projectsLength % 3 === 0){
+              $('#projects').append('<div class="row"><div>');
+              console.log('adding Row')
+            }
 
-            html = '<li class="'+project.state+' layout-centered layout-crotchet"> \
-              <div class="project"> \
-                <h2> <a href="'+project.code_url+'">'+project.name+'</a> </h2> \
-                <hr /> \
-                <a class="icon-tools" href="'+project.travis+'"> Built '+project.when+' ago </a> \
-              </div> \
-            </li>'
+            var singleProject = '<li class="'+project.state+' layout-centered layout-crotchet project"> \
+                                    <h2> <a href="'+project.code_url+'">'+project.name+'</a> </h2> \
+                                  <hr /> \
+                                    <a class="icon-tools" href="'+project.travis+'"> Built '+project.when+'</a> \
+                                  </li>'
 
-            $("#projects").append(html);
-
+            $('.row').last().append(singleProject);
           }
-
         });
 
       }
@@ -73,7 +74,6 @@ $( document ).ready(function() {
 
 
   var projects = {{ projects | tojson }};
-
   $.each(projects, function(i, project){
 
     getProject(project);

--- a/brigade/templates/projectmonitor.html
+++ b/brigade/templates/projectmonitor.html
@@ -49,20 +49,23 @@ $( document ).ready(function() {
 
             repo = project.code_url.replace("https://github.com/","");
             project.travis = 'https://travis-ci.org/' + repo + '/builds/' + response[0].id
+
             var projectsLength = $('#projects').find('.row').children('.project').length;
-            console.log(projectsLength);
-            if (projectsLength === 0 || projectsLength % 3 === 0){
-              $('#projects').append('<div class="row"><div>');
-              console.log('adding Row')
+
+            if (projectsLength === 0 || projectsLength % 3 === 0) {
+              $('#projects').append('<div class="row"></div>');
             }
 
             var singleProject = '<li class="'+project.state+' layout-centered layout-crotchet project"> \
-                                    <h2> <a href="'+project.code_url+'">'+project.name+'</a> </h2> \
-                                  <hr /> \
-                                    <a class="icon-tools" href="'+project.travis+'"> Built '+project.when+'</a> \
-                                  </li>'
+                                  <h2> <a href="'+project.code_url+'">'+project.name+'</a> </h2> \
+                                <hr /> \
+                                  <a class="icon-tools" href="'+project.travis+'"> Built '+project.when+'</a> \
+                                </li>'
 
             $('.row').last().append(singleProject);
+            if (projectsLength % 3) {
+              $('.row').last().fadeIn(400).css('display','flex');
+            }
           }
         });
 


### PR DESCRIPTION
This PR is just a front-end fix to make the project boxes display at even heights.

Before:
<img width="715" alt="screen shot 2016-01-13 at 4 29 40 pm" src="https://cloud.githubusercontent.com/assets/1418949/12312275/ff1ef718-ba12-11e5-983d-6ffddaaa8b8b.png">

After:

<img width="705" alt="screen shot 2016-01-13 at 4 29 52 pm" src="https://cloud.githubusercontent.com/assets/1418949/12312279/0675408a-ba13-11e5-8a61-6049d8058200.png">

This change makes use of display: table-cell, which is supported by IE 8 and above. I wish there wasn't as much JS in the view itself, but that could be something to refactor later.

