### PR TITLE
Fix iframe src attribute

### DIFF
--- a/brigade/templates/projects_embed.html
+++ b/brigade/templates/projects_embed.html
@@ -47,7 +47,7 @@ function updateSnippet () {
   var code = $('#embed');
   var widget = $('#widget');
 
-  var embedString = '/brigade/projects/search';
+  var embedString = 'https://www.codeforamerica.org/brigade/projects/search';
   if (org){
     embedString += '?';
     embedString += 'organization_id=' + org;


### PR DESCRIPTION
Addresses #437 where the src attribute in the iframe to share projects would drop "https://codeforamerica.org" if the user switches to another organization.