### PR TITLE
Add redirect from / -> /brigade

### DIFF
--- a/brigade/views.py
+++ b/brigade/views.py
@@ -1,5 +1,5 @@
 # -- coding: utf-8 --
-from flask import current_app, render_template, request, redirect, make_response, flash, session
+from flask import current_app, render_template, request, redirect, make_response, flash, session, url_for
 from . import brigade as app
 from datetime import datetime
 from operator import itemgetter
@@ -67,6 +67,10 @@ def get_projects(projects, url, limit=10):
 #
 # ROUTES
 #
+
+@app.route('/', methods=['GET'])
+def redirect_to_index():
+    return redirect(url_for('.index'))
 
 @app.route('/brigade/list', methods=["GET"])
 def brigade_list():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -140,5 +140,10 @@ class BrigadeTests(unittest.TestCase):
             project_name = soup.find_all('h3')
             self.assertEqual(u"TEST PROJECT", project_name[0].text.strip())
 
+    def test_homepage_redirect(self):
+        response = self.client.get("/")
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(flask.url_for('.index', _external=True), response.location)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In case you happen to go to https://brigade.codeforamerica.org, it
should redirect you to /brigade instead of failing. In the future we'll
probably want to resolve the routing situation.

This is a quick fix until I can remove the `/brigade` from the URLs.