### PR TITLE
Extract CfAPI methods into a separate module

### DIFF
--- a/brigade/__init__.py
+++ b/brigade/__init__.py
@@ -3,7 +3,7 @@ from filters import filters
 
 brigade = Blueprint('brigade', __name__)
 
-def create_app(environ):
+def create_app():
     app = Flask(__name__, static_url_path='/brigade/static')
     app.config['SECRET_KEY'] = 'sekrit!'
 

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -65,7 +65,4 @@
   </script>
 
   {% block js %}{% endblock %}
-
-  <script src="http://archive.codeforamerica.org/script/global.js"></script>
-
 </html>

--- a/brigade/wsgi.py
+++ b/brigade/wsgi.py
@@ -1,4 +1,3 @@
-from os import environ
 from . import create_app
 
-app = create_app(environ)
+app = create_app()

--- a/cfapi/__init__.py
+++ b/cfapi/__init__.py
@@ -1,0 +1,49 @@
+from requests import get
+import json
+
+BASE_URL = "http://api.codeforamerica.org/api"
+
+def get_brigades():
+    # Get location of all civic tech orgs
+    got = get(BASE_URL + "/organizations.geojson")
+    geojson = got.json()
+    brigades = []
+
+    # Prepare the geojson for a map
+    for org in geojson["features"]:
+        # Add icon info for the map
+        org["properties"]["marker-symbol"] = "town-hall"
+        # Official Brigades get to be red
+        if "Official" in org["properties"]["type"]:
+            org["properties"]["marker-color"] = "#aa1c3a"
+        else:
+            # Other Brigades are grey
+            org["properties"]["marker-color"] = "#6D6E71"
+        # Grab only orgs with type Brigade
+        if "Brigade" in org["properties"]["type"]:
+            print org
+            brigades.append(org)
+
+    brigades = json.dumps(brigades)
+    return brigades
+
+# TODO: make a get_organization_projects wrapper so the URL doesn't need to be
+# passed in here.
+def get_projects(projects, url, limit=10):
+    ''' Load projects from the cfapi
+    '''
+    got = get(url)
+    new_projects = got.json()["objects"]
+    projects = projects + new_projects
+    if limit:
+        if len(projects) >= limit:
+            return projects
+    if "next" in got.json()["pages"]:
+        projects = get_projects(projects, got.json()["pages"]["next"], limit)
+    return projects
+
+def is_existing_organization(orgid):
+    ''' tests that an organization exists on the cfapi'''
+    got = get(BASE_URL + "/organizations.geojson").json()
+    orgids = [org["properties"]["id"] for org in got["features"]]
+    return orgid in orgids

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ if path.exists('.env'):
         if len(var) == 2 and not var[0].startswith('#'):
             environ[var[0]] = var[1]
 
-app = create_app(environ)
+app = create_app()
 manager = Manager(app)
 manager.add_command('runserver', Server(host='localhost', port='4000', use_debugger=True))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 class BrigadeTests(unittest.TestCase):
 
     def setUp(self):
-        self.app = create_app(os.environ)
+        self.app = create_app()
         self.app_context = self.app.app_context()
         self.app_context.push()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,6 +6,7 @@ import os
 import flask
 import httmock
 import re
+import cfapi
 from brigade import create_app
 import brigade.views as view_functions
 from bs4 import BeautifulSoup
@@ -31,13 +32,13 @@ class BrigadeTests(unittest.TestCase):
             return httmock.response(200, '{ "status_code" : 200, "msg" : "Almost finished... We need to confirm your email address. To complete the subscription process, please click the link in the email we just sent you."}')
         if url.geturl() == 'http://www.codeforamerica.org/fragments/email-signup.html' or url.geturl() == 'http://www.codeforamerica.org/fragments/global-footer.html':
             return httmock.response(200, '''<html>bunch of HTML</html>''')
-        if url.geturl() == 'https://www.codeforamerica.org/api/organizations/404':
+        if url.geturl() == cfapi.BASE_URL + '/organizations/404':
             return httmock.response(404, '{"status": "Resource Not Found"}')
-        if url.geturl() == 'https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco':
+        if url.geturl() == cfapi.BASE_URL + '/organizations/TEST-ORG':
             return httmock.response(200, '{"city": "San Francisco, CA"}')
-        if url.geturl() == "https://www.codeforamerica.org/api/organizations.geojson":
+        if url.geturl() == cfapi.BASE_URL + "/organizations.geojson":
             return httmock.response(200, '{"features" : [{ "properties" : { "id" : "TEST-ORG", "type" : "Brigade" } } ] }')
-        if url.geturl() == "https://www.codeforamerica.org/api/projects/1":
+        if url.geturl() == cfapi.BASE_URL + "/projects/1":
             return httmock.response(200, '''
                     {
                       "code_url": "https://github.com/jmcelroy5/sf-in-progress",
@@ -113,8 +114,9 @@ class BrigadeTests(unittest.TestCase):
 
     def test_good_links(self):
         ''' Test that normal Brigade links are working '''
-        response = self.client.get("/brigade/Code-for-San-Francisco/")
-        self.assertEqual(200, response.status_code)
+        with httmock.HTTMock(self.response_content):
+            response = self.client.get("/brigade/TEST-ORG/")
+            self.assertEqual(200, response.status_code)
 
     def test_404(self):
         ''' Test for 404 links '''


### PR DESCRIPTION
This has a few motivations:

- the views.py file is pretty massive
- this allows them to be unit tested easier
- extracting these methods will allow them to be reused elsewhere in the
app (outside of the `brigade` blueprint)
- it makes the responsibility clear

This required some modifications to the tests, including one test which
accidentally was un-stubbed and reaching out to the internet.