### PR TITLE
Add sitemap.xml to Brigade site

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,9 @@
     },
     "GITHUB_CLIENT_SECRET": {
       "required": true
+    },
+    "SITEMAP_URL_SCHEME": {
+      "required": true
     }
   },
   "formation": {

--- a/brigade/__init__.py
+++ b/brigade/__init__.py
@@ -1,7 +1,9 @@
-from flask import Blueprint, Flask
+from flask import Blueprint, Flask, url_for
+from flask_sitemap import Sitemap
 from filters import filters
+from sitemap import sitemap_blueprint
 
-brigade = Blueprint('brigade', __name__)
+brigade = Blueprint('brigade', __name__, static_folder='static')
 
 def create_app():
     app = Flask(__name__, static_url_path='/brigade/static')
@@ -9,6 +11,7 @@ def create_app():
 
     app.register_blueprint(brigade)
     app.register_blueprint(filters)
+    app.register_blueprint(sitemap_blueprint)
     return app
 
 from . import views

--- a/brigade/sitemap.py
+++ b/brigade/sitemap.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+import json
+
+from flask_sitemap import Sitemap
+from flask import Blueprint
+
+from cfapi import get_brigades
+
+class SitemapBlueprint(Blueprint):
+    '''
+    Contain all the logic for generating a sitemap.xml
+    '''
+    STATIC_ROUTES = [
+        'brigade.index',
+        'brigade.about',
+        'brigade.organize',
+        'brigade.tools',
+    ]
+
+    PER_BRIGADE_ROUTES = [
+        'brigade.brigade',
+        'brigade.projects',
+    ]
+
+    def register(self, app, options, first_registration=False):
+        sitemap = Sitemap(app=app)
+
+        @sitemap.register_generator
+        def index():
+            # (route, options, lastmod, changefreq, priority)
+            for route in self.STATIC_ROUTES:
+              yield (route, {}, None, 'monthly', '0.5')
+
+            brigades = get_brigades()
+            for brigade in json.loads(brigades):
+                last_updated = datetime.fromtimestamp(brigade['properties']['last_updated'])
+
+                for route in self.PER_BRIGADE_ROUTES:
+                  yield (
+                      route,
+                      { 'brigadeid': brigade['id'] },
+                      last_updated.strftime("%Y-%m-%d"),
+                      'weekly',
+                      '1.0'
+                  )
+
+sitemap_blueprint = SitemapBlueprint('sitemap', __name__)

--- a/brigade/static/robots.txt
+++ b/brigade/static/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://brigade.codeforamerica.org/sitemap.xml

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -1,5 +1,5 @@
 # -- coding: utf-8 --
-from flask import current_app, render_template, request, redirect, make_response, flash, session, url_for
+from flask import current_app, render_template, request, redirect, make_response, flash, session, url_for, send_from_directory
 from . import brigade as app
 import cfapi
 from datetime import datetime
@@ -22,10 +22,6 @@ requests_logger.setLevel(logging.WARNING)
 #
 # ROUTES
 #
-
-@app.route('/', methods=['GET'])
-def redirect_to_index():
-    return redirect(url_for('.index'))
 
 @app.route('/brigade/list', methods=["GET"])
 def brigade_list():
@@ -263,3 +259,11 @@ def project_monitor(brigadeid=None):
             projects_with_tests.append(project)
 
     return render_template('monitor.html', projects=projects_with_tests, org_name=brigadeid)
+
+@app.route('/robots.txt')
+def static_from_root():
+    return send_from_directory(app.static_folder, request.path[1:])
+
+@app.route('/', methods=['GET'])
+def redirect_to_index():
+    return redirect(url_for('.index'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 httmock
 Flask-Script
 beautifulsoup4
+flask-sitemap

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -37,7 +37,7 @@ class BrigadeTests(unittest.TestCase):
         if url.geturl() == cfapi.BASE_URL + '/organizations/TEST-ORG':
             return httmock.response(200, '{"city": "San Francisco, CA"}')
         if url.geturl() == cfapi.BASE_URL + "/organizations.geojson":
-            return httmock.response(200, '{"features" : [{ "properties" : { "id" : "TEST-ORG", "type" : "Brigade" } } ] }')
+            return httmock.response(200, '{"features" : [{ "id": "TEST-ORG", "properties" : { "id" : "TEST-ORG", "type" : "Brigade", "last_updated": 1510874211 } } ] }')
         if url.geturl() == cfapi.BASE_URL + "/projects/1":
             return httmock.response(200, '''
                     {
@@ -146,6 +146,12 @@ class BrigadeTests(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(302, response.status_code)
         self.assertEqual(flask.url_for('.index', _external=True), response.location)
+
+    def test_sitemap(self):
+        with httmock.HTTMock(self.response_content):
+            response = self.client.get('/sitemap.xml')
+            self.assertEqual(200, response.status_code)
+            self.assertIn('<loc>http://localhost/brigade/TEST-ORG/</loc>', response.data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will help search engines discover content on the site. By using the
library flask-sitemap, we can create this without doing too much XML
hacking.

Note that this requires SITEMAP_URL_SCHEME environment variable to be
set to "https" in order to generate secure links by default.