### PR TITLE
 Move almost all JS into one "application" file 

### DIFF
--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -1,0 +1,48 @@
+window.Brigade = window.Brigade || {};
+
+window.Brigade.initializeMap = function(geoJSON) {
+  // Provide your access token
+  L.mapbox.accessToken = 'pk.eyJ1IjoiY29kZWZvcmFtZXJpY2EiLCJhIjoiSTZlTTZTcyJ9.3aSlHLNzvsTwK-CYfZsG_Q';
+
+  // Create a map in the div #map
+  var map = L.mapbox.map('map', 'codeforamerica.map-hhckoiuj');
+
+  map.legendControl.setPosition('topright');
+  map.legendControl.addLegend('<img src="https://www.codeforamerica.org/brigade/static/images/red-marker.png" style="vertical-align: middle;"><strong>Official Brigade</strong>');
+  map.zoomControl.setPosition('topright');
+
+  var latlon = [27, -85], zoom = 2;
+
+  map.setView(latlon, zoom);
+  map.featureLayer.setGeoJSON(geoJSON);
+
+  map.featureLayer.on('click', function(e) {
+    var brigadeId = e.layer.feature.properties.name.replace(/\s+/g, '-');
+    window.open(brigadeId, "_self");
+  });
+};
+
+window.Brigade.initializeProjects = function(id, query, status) {
+  $(id).masonry({
+    itemSelector: '.project',
+    "gutter" : 20
+  });
+
+  if (query) {
+    ga('send', 'event', 'Project Search', 'search', query, 1);
+  }
+
+  if (status) {
+    ga('send', 'event', 'Project Search', 'search', status, 1);
+  }
+};
+
+window.Brigade.init = function() {
+  // Generate list of brigades
+  if ($(window).width() > 480){
+    $('#map').css("height", $(window).height() - $(".global-header").height() - 1);
+    $('#overlay').css("height", ($(window).height() - $(".global-header").height()));
+  }
+};
+
+document.addEventListener('DOMContentLoaded', window.Brigade.init);

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -46,6 +46,7 @@
 
     </div>
 
+    {% block analytics %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -55,8 +56,10 @@
       ga('require', 'linkid', 'linkid.js');
       ga('send', 'pageview');
     </script>
+    {% endblock %}
+    {% block js %}
     <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script src="{{ url_for('static', filename='js/application.js') }}"></script>
-    {% block js %}{% endblock %}
+    {% endblock %}
   </body>
 </html>

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -14,8 +14,6 @@
 
     <link rel="shortcut icon" type="image/x-icon" href="https://style.codeforamerica.org/1/favicon.ico">
     <link rel="apple-touch-icon-precomposed" href="https://style.codeforamerica.org/1/style/favicons/60x60/flag-red.png"/>
-
-    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
   </head>
 
   <body>
@@ -48,17 +46,17 @@
 
     </div>
 
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-20825280-1', 'auto');
+      ga('require', 'linkid', 'linkid.js');
+      ga('send', 'pageview');
+    </script>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="{{ url_for('static', filename='js/application.js') }}"></script>
+    {% block js %}{% endblock %}
   </body>
-
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-20825280-1', 'auto');
-    ga('require', 'linkid', 'linkid.js');
-    ga('send', 'pageview');
-  </script>
-
-  {% block js %}{% endblock %}
 </html>

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -35,7 +35,7 @@
             <li><a href="/brigade/organize">Organize a Brigade</a></li>
             <li><a href="/brigade/projects">Project Finder</a></li>
             <li><a href="/brigade/about">About Us</a></li>
-            <li><a id="donate-link" href="https://secure.codeforamerica.org/page/contribute/default?source_codes=Brigade-page" class="button">Donate</a></li>
+            <li><a id="donate-link" href="https://secure.codeforamerica.org/page/contribute/default?source_codes=Brigade-page{% if brigade %}&brigade={{ brigade.name }}{% endif %}" class="button">Donate</a></li>
           </ul>
         </nav>
       </div>

--- a/brigade/templates/brigade.html
+++ b/brigade/templates/brigade.html
@@ -132,15 +132,6 @@
 
   $(document).ready(function(){
 
-    // Resize iframe to fit content
-    function resize(){
-      var widget_iframe = document.getElementById('widget');
-      issues_document = widget_iframe.contentWindow.document;
-      if(issues_document){
-        widget_iframe.height = issues_document.body.scrollHeight + "px";
-      }
-    }
-
     // SIGN UP FORM
     $('input[name="group[10273][8192]"]').prop('checked',true);
     $('input[name=REFERRAL]').val("/brigade/{{brigadeid}}");

--- a/brigade/templates/brigade.html
+++ b/brigade/templates/brigade.html
@@ -131,18 +131,6 @@
 <script>
 
   $(document).ready(function(){
-
-    // SIGN UP FORM
-    $('input[name="group[10273][8192]"]').prop('checked',true);
-    $('input[name=REFERRAL]').val("/brigade/{{brigadeid}}");
-    $("#email-signup-data-form").append('<input type="hidden" name="brigade_id" value="{{brigadeid}}" />');
-    $("#email-signup-data-form").on( "submit", function( event ) {
-      event.preventDefault();
-      $.post("/brigade/signup/", $( this ).serialize(), function(response){
-        console.log(response);
-      }, "json");
-    });
-
     // Donate param
     $("#donate-link").attr("href", $("#donate-link").attr("href") + "&brigade={{ brigade.name }}");
   });

--- a/brigade/templates/brigade.html
+++ b/brigade/templates/brigade.html
@@ -126,14 +126,3 @@
 
   </section>
 {% endblock %}
-
-{% block js %}
-<script>
-
-  $(document).ready(function(){
-    // Donate param
-    $("#donate-link").attr("href", $("#donate-link").attr("href") + "&brigade={{ brigade.name }}");
-  });
-
-</script>
-{% endblock %}

--- a/brigade/templates/brigade_list.html
+++ b/brigade/templates/brigade_list.html
@@ -24,26 +24,3 @@
   </div>
 
 {% endblock %}
-
-{% block js %}
-
-<script>
-
-  // Generate list of brigades
-  if ($(window).width() > 480){
-    $('#map').css("height", $(window).height() - $(".global-header").height() - 1);
-    $('#overlay').css("height", ($(window).height() - $(".global-header").height()));
-  }
-
-  // SIGN UP FORM
-  $('input[name="group[10273][8192]"]').prop('checked',true);
-  $('input[name=REFERRAL]').val("/brigade");
-  $("#email-signup-data-form").on( "submit", function( event ) {
-    event.preventDefault();
-    $.post("/brigade/signup/", $( this ).serialize(), function(response){
-      console.log(response);
-    }, "json");
-  });
-
-</script>
-{% endblock %}

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -30,6 +30,7 @@
 {% endblock %}
 
 {% block js %}
+{{ super() }}
 <script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.js'></script>
 <link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css' rel='stylesheet' />
 

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -30,85 +30,10 @@
 {% endblock %}
 
 {% block js %}
-
-<script src="{{ url_for('static', filename='js/turf.min.js') }}"></script>
-
 <script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.js'></script>
 <link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css' rel='stylesheet' />
 
 <script>
-  if ($(window).width() > 480){
-    $('#map').css("height", $(window).height() - $(".global-header").height() - 1);
-    $('#overlay').css("height", ($(window).height() - $(".global-header").height()));
-  }
-
-
-  // Provide your access token
-  L.mapbox.accessToken = 'pk.eyJ1IjoiY29kZWZvcmFtZXJpY2EiLCJhIjoiSTZlTTZTcyJ9.3aSlHLNzvsTwK-CYfZsG_Q';
-
-  // Create a map in the div #map
-  var map = L.mapbox.map('map', 'codeforamerica.map-hhckoiuj');
-
-  map.legendControl.setPosition('topright');
-  map.legendControl.addLegend('<img src="https://www.codeforamerica.org/brigade/static/images/red-marker.png" style="vertical-align: middle;"><strong>Official Brigade</strong>');
-  map.zoomControl.setPosition('topright');
-
-  var latlon = [27, -85], zoom = 2;
-
-  map.setView(latlon, zoom);
-  map.featureLayer.setGeoJSON({{ brigades | safe }});
-
-  map.featureLayer.on('click', function(e) {
-    var brigadeId = e.layer.feature.properties.name.replace(/\s+/g, '-');
-    window.open(brigadeId, "_self");
-  });
-
-
-  // This uses the HTML5 geolocation API, which is available on
-  // most mobile browsers and modern browsers, but not in Internet Explorer
-  //
-  // See this chart of compatibility for details:
-  // http://caniuse.com/#feat=geolocation
-  if (!navigator.geolocation) {
-      geolocate.innerHTML = 'Geolocation is not available';
-  } else {
-      geolocate.onclick = function (e) {
-          $("#geolocate").addClass("button-progress").text("Finding your local Brigade");
-          e.preventDefault();
-          e.stopPropagation();
-          map.locate();
-      };
-  }
-
-  // Once we've got a position, zoom and center the map
-  // on it, and add a single marker.
-  map.on('locationfound', function(e) {
-    var my_lnglat = [e.latlng.lng, e.latlng.lat]
-    var point = turf.point(my_lnglat);
-    var against = turf.featurecollection(brigade_points);
-    var nearest = turf.nearest(point,against);
-    var distance = turf.distance(point, nearest, "miles");
-    if (distance > 200) {
-      $("#geolocate").removeClass("button-progress").addClass("button-disabled");
-      $(".alert-success").show();
-    }
-    var brigadeId = nearest.properties.name.replace(/\s+/g, '-');
-    window.open(brigadeId, "_self");
-  });
-
-  // If the user chooses not to allow their location
-  // to be shared, display an error message.
-  map.on('locationerror', function() {
-      geolocate.innerHTML = 'Position could not be found';
-  });
-
-  var brigades = {{ brigades | safe }};
-  var brigade_points = []
-  $.each(brigades, function(i,brigade){
-    brigade_point = turf.point(brigade.geometry.coordinates, brigade.properties);
-    brigade_points.push(brigade_point);
-  });
-
-
+  window.Brigade.initializeMap({{ brigades | safe }});
 </script>
 {% endblock %}

--- a/brigade/templates/numbers.html
+++ b/brigade/templates/numbers.html
@@ -133,11 +133,3 @@
 
   </section>
 {% endblock %}
-
-{% block js %}
-
-  <script>
-    $("#signupformdiv").hide();
-  </script>
-
-{% endblock %}

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -118,22 +118,12 @@
 {% endblock %}
 
 {% block js %}
-  <script>
-    {% if request.args.get('q') %}
-    ga('send', 'event', 'Project Search', 'search', "{{ request.args.get('q') }}", 1 );
-    {% endif %}
-    {% if request.args.get('status') %}
-    ga('send', 'event', 'Project Search', 'search', "{{ request.args.get('status') }}", 1 );
-    {% endif %}
-  </script>
-
   <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/3.3.2/masonry.pkgd.min.js"></script>
 
   <script>
-    $('#projects').masonry({
-      itemSelector: '.project',
-      "gutter" : 20
-    });
+    window.Brigade.initializeProjects('#projects',
+      {{ request.args.get('q') | tojson }},
+      {{ request.args.get('status') | tojson }}
+    );
   </script>
-
 {% endblock %}

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -118,6 +118,7 @@
 {% endblock %}
 
 {% block js %}
+  {{ super() }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/3.3.2/masonry.pkgd.min.js"></script>
 
   <script>

--- a/brigade/templates/rsvps.html
+++ b/brigade/templates/rsvps.html
@@ -50,6 +50,7 @@
 {% endblock %}
 
 {% block js %}
+  {{ super() }}
   <script type="text/javascript" src="https://www.google.com/jsapi"></script>
   <script type="text/javascript">
     google.load("visualization", "1.1", {packages:["corechart"]});


### PR DESCRIPTION
This begins a trend to move all JS into an application bundle file,
rather than inserting it dynamically on each page. Child views are still
responsible for calling that page's JS initialization.

I also removed a bunch of JS that seemed unused, and moved the remainder
to the bottom of the <body> (instead of in the `<head>` and outside the
`<body>` -- two locations to avoid putting JS!)