### PR TITLE
Remove reference to This Week in Civic Tech

### DIFF
--- a/brigade/templates/organize/index.html
+++ b/brigade/templates/organize/index.html
@@ -13,7 +13,6 @@
     <p><a href="checklist/">Brigade Organizer's Checklist</a>: Learn how Code for America supports civic hack nights and Official Brigades.</p> 
     <p><a href="calendar/">Brigade Organizer’s Calendar</a>: Overview of days of action, workshops, and more.</p>
     <p><a href="playbook/">Brigade Organizer’s Playbook</a>: Deep dive into three areas key to running a sustainable Brigade.</p>
-    <p><a href="http://www.codeforamerica.org/blog/tag/civictech/" target="_blank">This Week in Civic Tech</a>: Learn what other groups across the Brigade network are doing.</p>
     <p><a href="https://cfa.typeform.com/to/uxPQH6" class="button button-l" target="_blank" onClick="ga('send', 'event', 'Organizer Forms', 'click', 'New-to-organizing form');">New to organizing?</a> Tell us a little bit about yourself so we can help you get started.</p>
   </div>
 </section>


### PR DESCRIPTION
Let's remove the link to This Week in Civic Tech from the organize page for now.