### PR TITLE
Fix header overlap issue on mobile

### DIFF
--- a/brigade/static/css/style.css
+++ b/brigade/static/css/style.css
@@ -98,6 +98,10 @@ h2 {
 /* MOBILE VIEW*/
 @media (max-width: 40em) {
 
+  .global-header {
+    position: static;
+  }
+
   main {
     margin-top: 50px;
   }


### PR DESCRIPTION
This is a temporary fix until we rework the site's navigation. It addresses an issue on narrower screens where the header overlaps the main content.