### PR TITLE
Automatically track all internal & external clicks

### DIFF
--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -69,8 +69,6 @@ window.Brigade.init = function() {
     const targetCategory = el.target.dataset.analyticsCategory;
     const isExternal = !targetHref.startsWith(window.location.origin);
 
-    debugger
-
     ga('send', 'event', {
       eventCategory: targetCategory || (isExternal ? 'External Link Click' : 'Link Click'),
       eventAction: 'click',

--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -17,7 +17,19 @@ window.Brigade.initializeMap = function(geoJSON) {
   map.featureLayer.setGeoJSON(geoJSON);
 
   map.featureLayer.on('click', function(e) {
-    var brigadeId = e.layer.feature.properties.name.replace(/\s+/g, '-');
+    var brigadeName = e.layer.feature.properties.name;
+
+    ga('send', 'event', {
+      eventCategory: 'Map Click',
+      eventAction: 'click',
+      eventLabel: brigadeName,
+
+      // see: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+      // Supported in modern non-Safari browsers.
+      transport: 'beacon'
+    });
+
+    var brigadeId = brigadeName.replace(/\s+/g, '-');
     window.open(brigadeId, "_self");
   });
 };
@@ -43,6 +55,32 @@ window.Brigade.init = function() {
     $('#map').css("height", $(window).height() - $(".global-header").height() - 1);
     $('#overlay').css("height", ($(window).height() - $(".global-header").height()));
   }
+
+  // Track all link clicks as explicit events.
+  //
+  // The event's label will be given by either the <a title> attribute or the
+  // link URL.
+  //
+  // Override the event's category with `data-target-category`, e.g.:
+  //   <a data-target-category="Some Other Event Category">
+  $(document).on('click', 'a', function(el) {
+    const targetHref = el.target.href;
+    const targetTitle = el.target.title;
+    const targetCategory = el.target.dataset.analyticsCategory;
+    const isExternal = !targetHref.startsWith(window.location.origin);
+
+    debugger
+
+    ga('send', 'event', {
+      eventCategory: targetCategory || (isExternal ? 'External Link Click' : 'Link Click'),
+      eventAction: 'click',
+      eventLabel: targetTitle || targetHref,
+
+      // see: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+      // Supported in modern non-Safari browsers.
+      transport: 'beacon'
+    })
+  });
 };
 
 document.addEventListener('DOMContentLoaded', window.Brigade.init);

--- a/brigade/templates/about.html
+++ b/brigade/templates/about.html
@@ -20,7 +20,7 @@
     <div class="layout-semibreve layout-centered">
         <h2>Code of Conduct</h2>
         <p>Code for America has a Code of Conduct that applies to our activities, events, and digital forums. We do not tolerate discrimiation or harrassment of any kind.</p>
-        <a class="button" href="https://github.com/codeforamerica/codeofconduct">Check out our full Code of Conduct</a>
+        <a class="button" href="https://github.com/codeforamerica/codeofconduct" title="Code of Conduct on Github">Check out our full Code of Conduct</a>
     </div>
 </section>
 

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -33,8 +33,8 @@
             <li><a href="/brigade/organize">Organize a Brigade</a></li>
             <li><a href="/brigade/projects">Project Finder</a></li>
             <li><a href="/brigade/about">About Us</a></li>
-            <li><a href="http://slack.codeforamerica.org" target="_blank" onclick="ga('send', 'event', 'Slack Sign-up', 'click', 'Slack sign-up form');">Join us on Slack</a></li>
-            <li><a id="donate-link" href="https://secure.codeforamerica.org/page/contribute/default?source_codes=Brigade-page{% if brigade %}&brigade={{ brigade.name }}{% endif %}" class="button">Donate</a></li>
+            <li><a href="http://slack.codeforamerica.org" target="_blank" title="Slack sign-up form">Join us on Slack</a></li>
+            <li><a id="donate-link" href="https://secure.codeforamerica.org/page/contribute/default?source_codes=Brigade-page{% if brigade %}&brigade={{ brigade.name }}{% endif %}" class="button" title="Donate Button">Donate</a></li>
           </ul>
         </nav>
 

--- a/brigade/templates/organize/checklist.html
+++ b/brigade/templates/organize/checklist.html
@@ -9,8 +9,8 @@
     <p>You can join the Brigade Network by organizing a civic hack night or an Official Brigade.</p>
     <p><b>A civic hack night</b> is a good place for new organizers to start. A civic hack night is a regular event that brings government, community partners, and residents together to work quickly and creatively on projects.</p>
     <p><b>An Official Brigade</b> takes a bit more work. An Official Brigade is a sustainable, civic hacking group that develops partnerships with government and community partners to provide strategic support with ongoing projects and events.</p>
-    <p>Code for America has a few requirements for groups joining the Brigade network, which are listed in the checklist below. If you run into blockers, sign up for <a href="https://cfa.typeform.com/to/XcfQ8H" onClick="ga('send', 'event', 'Organizer Forms', 'click', 'Office hours sign-up form');">Office Hours</a> or join us for a <a href="http://www.codeforamerica.org/brigade/organize/calendar">workshop</a>.</p>
-    <p><a href="https://cfa.typeform.com/to/n0AZet" class="button button-l" target="_blank" onClick="ga('send', 'event', 'Organizer Forms', 'click', 'Start-a-Brigade form');">Let us know</a> when you have everything in place and we'll help you access Code for America resources.</p>
+    <p>Code for America has a few requirements for groups joining the Brigade network, which are listed in the checklist below. If you run into blockers, sign up for <a href="https://cfa.typeform.com/to/XcfQ8H" title="Office hours sign-up-form">Office Hours</a> or join us for a <a href="http://www.codeforamerica.org/brigade/organize/calendar">workshop</a>.</p>
+    <p><a href="https://cfa.typeform.com/to/n0AZet" class="button button-l" target="_blank" title='Start-a-Brigade form'>Let us know</a> when you have everything in place and we'll help you access Code for America resources.</p>
 
 
     <table>

--- a/brigade/templates/organize/index.html
+++ b/brigade/templates/organize/index.html
@@ -13,7 +13,7 @@
     <p><a href="checklist/">Brigade Organizer's Checklist</a>: Learn how Code for America supports civic hack nights and Official Brigades.</p> 
     <p><a href="calendar/">Brigade Organizer’s Calendar</a>: Overview of days of action, workshops, and more.</p>
     <p><a href="playbook/">Brigade Organizer’s Playbook</a>: Deep dive into three areas key to running a sustainable Brigade.</p>
-    <p><a href="https://cfa.typeform.com/to/uxPQH6" class="button button-l" target="_blank" onClick="ga('send', 'event', 'Organizer Forms', 'click', 'New-to-organizing form');">New to organizing?</a> Tell us a little bit about yourself so we can help you get started.</p>
+    <p><a href="https://cfa.typeform.com/to/uxPQH6" class="button button-l" target="_blank"  title="New-to-organizing form">New to organizing?</a> Tell us a little bit about yourself so we can help you get started.</p>
   </div>
 </section>
 

--- a/brigade/templates/organize/playbook.html
+++ b/brigade/templates/organize/playbook.html
@@ -7,7 +7,7 @@
     <h2>Brigade Organizer's Playbook</h2>
     <p>The Brigade Organizer's Playbook focuses on the three areas key to running a sustainable Brigade: infrastructure, organizing, and building.</p>
     <p>The playbook is a work in progress. We will continue to build on its content, design, and format.</p>
-    <p><a href="{{ url_for('static', filename='Playbook_PDF_2_2016.pdf') }}" target="_blank" onClick="ga('send', 'event', 'Organizer Resources', 'download', 'Playbook PDF download');">Download</a> the playbook or <a href="https://docs.google.com/document/d/19bN5RWK5nQTpz0mHUViHrzHiommBUAMSztwNRzUcxYo/edit#" target="_blank" onClick="ga('send', 'event', 'Organizer Resources', 'view', 'Playbook Google Doc view');">view the Google doc</a>.</p>
+    <p><a href="{{ url_for('static', filename='Playbook_PDF_2_2016.pdf') }}" target="_blank" title="Playbook PDF Download">Download</a> the playbook or <a href="https://docs.google.com/document/d/19bN5RWK5nQTpz0mHUViHrzHiommBUAMSztwNRzUcxYo/edit#" target="_blank" title="Playbook Google Doc view">view the Google doc</a>.</p>
   </div>
 
 </section>

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -45,14 +45,14 @@
             {% endif %}
 
             {% if not brigade %}
-              <p><small>Used by </small><a href="/brigade/{{ project.organization.id }}/projects">{{ project.organization.name }}</a></p>
+              <p><small>Used by </small><a href="/brigade/{{ project.organization.id }}/projects" data-analytics-category="Project Finder Click">{{ project.organization.name }}</a></p>
             {% endif %}
 
             {% if project.github_details %}
               {% if project.github_details.contributors %}
                 {% for i in range(5) %}
                   {% if project.github_details.contributors[i] %}
-                    <a href="{{ project.github_details.contributors[i].html_url }}">
+                    <a href="{{ project.github_details.contributors[i].html_url }}" data-analytics-category="Project Finder Click">
                       <img height="40" width="40" src="{{ project.github_details.contributors[i].avatar_url }}&s=40" style="border-radius: 5px;"/>
                     </a>
                   {% endif %}
@@ -68,10 +68,10 @@
 
             <p>
             {% if project.link_url %}
-              <a href="{{project.link_url}}" class="button-bold">View the project</a>
+              <a href="{{project.link_url}}" class="button-bold" data-analytics-category="Project Finder Click">View the project</a>
             {% endif %}
             {% if project.code_url %}
-              <a href="{{project.code_url}}" class="button-bold">Contribute on Github</a>
+              <a href="{{project.code_url}}" class="button-bold" data-anayltics-category="Project Finder Click">Contribute on Github</a>
             {% endif %}
             </p>
 
@@ -81,7 +81,7 @@
             {% if project.languages %}
             {% set comma = joiner(",") %}
               Written in
-              {% for lang in project.languages %}{{ comma() }} <a href="projects?q={{ lang }}">{{ lang }}</a>{% endfor %}
+              {% for lang in project.languages %}{{ comma() }} <a href="projects?q={{ lang }}" data-analytics-category="Project Finder Click" title="Projects in {{ lang }}">{{ lang }}</a>{% endfor %}
             </p>
             {% endif %}
 
@@ -89,7 +89,7 @@
             {% set comma = joiner(",") %}
             <p>
               Tagged with
-              {% for tag in project.tags %}{{ comma() }} <a href="projects?q={{ tag }}">{{ tag }}</a>{% endfor %}
+              {% for tag in project.tags %}{{ comma() }} <a href="projects?q={{ tag }}" data-analytics-category="Project Finder Click" title="Projects tagged {{ tag }}">{{ tag }}</a>{% endfor %}
             {% endif %}
             </p>
 


### PR DESCRIPTION
This adds a global event handler that tracks all clicks. The default
behavior is to track an event with category 'Link Click', action
'click', and label equal to the link's destination href.

However, this can be changed like so:

- if the link is to a different origin, the category changes to
'External Link Click'
- if the link has a "title" attribute, that is used in place of the
"href" attribute for the event's label
- if the link has a "data-analytics-category" attribute, that is used in
place of the default 'Link Click' category (the intent of this is to
allow a product area like the Project Finder to keep its analytics
separate from the rest of the site).

[Closes #469]