### PR TITLE
Extend card component

### DIFF
--- a/brigade/static/scss/atoms/_button.scss
+++ b/brigade/static/scss/atoms/_button.scss
@@ -1,0 +1,9 @@
+@import '../core/variables';
+
+//
+// Button
+//
+
+.button {
+  box-sizing: border-box !important; // TODO: Get rid of !important (the old CfA stylesheet we're using right now overides the button box-sizing)
+}

--- a/brigade/static/scss/molecules/_card.scss
+++ b/brigade/static/scss/molecules/_card.scss
@@ -5,32 +5,119 @@
 //
 
 .card {
+  font-weight: inherit;
+
+  display: flex;
+  flex-direction: row;
+
+  margin: 15px 0;
+
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+
+  flex-wrap: wrap;
+
+  /* Make the parts of each card full-width by default */
+  & > * {
+    flex: 100% 1;
+  }
+
+  &:hover {
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+  }
+
+  /* Make sure the first element in each part of the card doesn't have a top margin */
+  & > * > :first-child {
+    margin-top: 0;
+  }
+
+  /* Make sure the last element in each part of the card doesn't have a bottom margin */
+  & > * > :last-child {
+    margin-bottom: 0;
+  }
 }
 
-.card:hover {
-  box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+a.card {
+  color: inherit;
+  /* Remove any hover border if the card is a link */
+  &:hover {
+    border: 0;
+  }
 }
 
-.card-head {
-  color: $color-text-light;
-  background-color: $color-gray;
-  min-height: 29px;
+.card__header {
+  font-size: small;
+
+  padding: 10px;
+
+  border-bottom: solid $color-border-light 1px;
 }
 
-.card-body h3 {
-  padding: 10px 0;
-  border-bottom: 1px solid $color-border-dark;
+.card__body {
+  padding: 15px;
 }
 
-.card-head, 
-.card-body {
-  padding: 0 10px;
+.card__title {
+  font-size: 28px;
+  line-height: 1.2;
+
+  text-align: center;
 }
 
-@media (max-width: 768px) {
-  .card {
-    width: 95% !important;
-    margin: 0px !important;
+/* This is an area for a main card action, like a button or a link */
+.card__action {
+  text-align: center;
+
+  /* Make card action buttons full-width */
+  .button,
+  .button:link {
+    width: 100%;
+  }
+}
+
+.card__footer {
+  font-size: small;
+  line-height: 1.2;
+
+  padding: 15px;
+
+  border-top: solid $color-border-light 1px;
+}
+
+.card__icon {
+  font-size: 52px;
+
+  padding: 15px;
+
+  text-align: center;
+  img {
+    max-height: 52px;
+  }
+}
+
+.card--horizontal {
+  @media (min-width: 40em) {
+    .card__aside {
+      display: flex;
+
+      text-align: center;
+
+      border-right: solid $color-border-light 1px;
+
+      flex: 1 auto;
+      justify-content: center;
+      align-items: center;
+    }
+    .card__body {
+      display: flex;
+      flex-direction: column;
+
+      flex: 3 0;
+    }
+    .card__title {
+      text-align: left;
+    }
+    .card__action {
+      margin-top: auto;
+    }
   }
 }

--- a/brigade/static/scss/organisms/_card-row.scss
+++ b/brigade/static/scss/organisms/_card-row.scss
@@ -1,0 +1,23 @@
+@import '../core/variables';
+
+//
+// Card Row
+//
+
+@media (min-width: 40em) { 
+
+  .card-row {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .card-row > * {
+    margin-right: 15px; // TODO: Set up some standard spacing variables
+    flex: 1;
+  }
+
+  .card-row:last-child {
+    margin-right: 0;
+  }
+
+}

--- a/brigade/static/scss/organisms/_component-grid.scss
+++ b/brigade/static/scss/organisms/_component-grid.scss
@@ -1,0 +1,22 @@
+@import '../core/variables';
+
+//
+// Grid
+//
+
+/* On wider screens, the grid component uses flexbox to create a row of evenly distributed items that take up the full width of the screen */
+
+@media (min-width: 40em) { 
+  .grid {
+    display: flex;
+    flex-direction: row;
+  }
+  .grid > .card {
+    margin-right: 15px; // TODO: Set up some standard spacing variables
+    flex: 1;
+    display: flex;
+  }
+  .grid:last-child.card {
+    margin-right: 0;
+  }
+}

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -6,6 +6,7 @@
 @import 'core/base';
 
 // Atoms
+@import 'atoms/button';
 @import 'atoms/input';
 @import 'atoms/list';
 @import 'atoms/table';
@@ -19,6 +20,7 @@
 
 // Organisms
 @import 'organisms/global-header';
+@import 'organisms/component-grid';
 
 // Templates
 @import 'templates/brigade-profile';

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -19,8 +19,8 @@
 @import 'molecules/searchbar';
 
 // Organisms
+@import 'organisms/card-row';
 @import 'organisms/global-header';
-@import 'organisms/component-grid';
 
 // Templates
 @import 'templates/brigade-profile';

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -14,6 +14,10 @@
 
     <link rel="shortcut icon" type="image/x-icon" href="https://style.codeforamerica.org/1/favicon.ico">
     <link rel="apple-touch-icon-precomposed" href="https://style.codeforamerica.org/1/style/favicons/60x60/flag-red.png"/>
+
+    <!-- FontAwesome Icons -->
+    <link href="https://use.fontawesome.com/releases/v5.0.4/css/all.css" rel="stylesheet">
+
   </head>
 
   <body id="{% block page_id %}{% endblock %}">

--- a/brigade/templates/projects.html
+++ b/brigade/templates/projects.html
@@ -35,12 +35,9 @@
       {% for project in projects %}
         <li class="project card">
 
-          <div class="card-head">
-          </div>
+          <div class="card__body">
 
-          <div class="card-body">
-
-            <h3>{{project.name}}</h3>
+            <h3 class="card__title">{{project.name}}</h3>
 
             {% if project.description %}
               <p>{{project.description}}</p>
@@ -77,10 +74,11 @@
             {% endif %}
             </p>
 
-            <small>
+          </div> <!-- card-body -->
 
-            <p>
+          <div class="card__footer">
             {% if project.languages %}
+            <p>
             {% set comma = joiner(",") %}
               Written in
               {% for lang in project.languages %}{{ comma() }} <a href="projects?q={{ lang }}" data-analytics-category="Project Finder Click" title="Projects in {{ lang }}">{{ lang }}</a>{% endfor %}
@@ -92,16 +90,13 @@
             <p>
               Tagged with
               {% for tag in project.tags %}{{ comma() }} <a href="projects?q={{ tag }}" data-analytics-category="Project Finder Click" title="Projects tagged {{ tag }}">{{ tag }}</a>{% endfor %}
-            {% endif %}
             </p>
+            {% endif %}
 
             {% if project.last_updated %}
               <p>Updated {{project.last_updated | timesince}}</p>
             {% endif %}
-
-            </small>
-
-          </div> <!-- card-body -->
+          </div>
 
         </li> <!-- project card -->
 

--- a/brigade/templates/styleguide.html
+++ b/brigade/templates/styleguide.html
@@ -126,6 +126,63 @@
 
   </div>
 
+  <div class="layout-semibreve">
+    <h2>Card row</h2>
+  </div>
+
+  <div class="layout-semibreve">
+    <div class="card-row">
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+          <div class="card__action">
+            <a href="#" class="button">Card Action Button</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-row">
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+          <div class="card__action">
+            <a href="#" class="button">Card Action Button</a>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>
 </section>
 

--- a/brigade/templates/styleguide.html
+++ b/brigade/templates/styleguide.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<section>
+  <div class="layout-semibreve">
+    <h1>Website Style Guide</h1>
+  </div>
+</section>
+
+<section>
+
+  <div class="layout-semibreve">
+    <h2>Cards</h2>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Card</h3>
+    <div class="layout-minim">
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Card with action</h3>
+    <div class="layout-minim">
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+          <div class="card__action">
+            <a href="#" class="button">Card Action Button</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Card with header</h3>
+    <div class="layout-minim">
+      <div class="card">
+        <div class="card__header">
+          Header text
+        </div>
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Card with footer</h3>
+    <div class="layout-minim">
+      <div class="card">
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+        <div class="card__footer">
+          Footer text
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Card with icon</h3>
+    <div class="layout-minim">
+      <div class="card">
+        <div class="card__icon">
+          <i class="fas fa-laptop"></i>
+        </div>
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Variant: card--horizontal</h3>
+    
+    <div class="layout-minim">
+      <div class="card card--horizontal">
+        <div class="card__header">
+          Header text
+        </div>
+        <div class="card__aside">
+          <div class="card__icon">
+            <i class="fas fa-laptop"></i>
+          </div>
+        </div>
+        <div class="card__body">
+          <h2 class="card__title">Card title</h2>
+          <p>
+            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
+          </p>
+          <div class="card__action">
+            <a href="#" class="button">Card action</a>
+          </div>
+        </div>
+        <div class="card__footer">
+          Footer text
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+</section>
+
+{% endblock %}

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -136,6 +136,11 @@ def free_software_show(software):
     return render_template(template_path)
 
 
+@app.route("/styleguide/")
+def styleguide():
+    return render_template("styleguide.html")
+
+
 @app.route("/brigade/projects")
 @app.route("/brigade/<brigadeid>/projects")
 def projects(brigadeid=None):


### PR DESCRIPTION
This builds up the `.card` components so they now have a header, body, footer, icon etc. and adds a variant, `.card--horizontal` that displays the body and an `.aside` element side-by-side on wider screens.
This also fixes a box-sizing issue with buttons, and adds a simple starter _stylesheet_ page at `/stylesheet` as a space to preview component style changes.