### PR TITLE
Make sure to bust CSS cache when webpack build changes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
   },
 
   plugins: [
-    new ExtractTextPlugin('[name].[chunkhash].css'),
+    new ExtractTextPlugin('[name].[contenthash].css'),
     new ManifestRevisionPlugin(path.join('brigade', 'build', 'manifest.json'), {
       rootAssetPath: rootAssetPath,
       extensionsRegex: /\.js/,


### PR DESCRIPTION
I noticed that the CSS filename we were serving didn't change between
multiple deploys, which seems wrong. Whenever the content of the CSS
file changes, so too should its filename.

The problem seems to stem from the ExtractTextPlugin. [Its docs recommend
"[contenthash]" instead of "[chunkhash]"][1]. (Perhaps the "[chunkhash]"
was was always evaluating to the hash of an empty string after the text
had been extracted?)

Note that this appears to currently work fine for javascript.

[1]: https://github.com/webpack-contrib/extract-text-webpack-plugin#options