### PR TITLE
Update event description filter to use 'tags' rather than 'type'

### DIFF
--- a/filters/__init__.py
+++ b/filters/__init__.py
@@ -28,7 +28,7 @@ def join_list(value):
 
 @filters.app_template_filter("brigade_description")
 def brigade_description(brigade):
-    if "Official" in brigade['type'] and "Brigade" in brigade['type']:
+    if "tags" in brigade and "Brigade" in brigade["tags"]:
         return "{0} is a group of volunteers in {1} working on projects with government and " \
                "community partners to improve peoples' lives.".format(
                     brigade['name'], brigade['city'])


### PR DESCRIPTION
The filter function was using the 'type' field from the API, but we've
switched to using 'tags' instead. As a result, some brigade pages (where
the Brigade Information doesn't have a type defined) weren't loading --
for example, [Code for Muskogee](https://brigade.codeforamerica.org/brigade/Code-for-Muskogee/). This fixes that error.