### PR TITLE
Use "bright-v8" instead of default mapbox style layer

### DIFF
--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -5,10 +5,15 @@ window.Brigade.initializeMap = function(geoJSON) {
   L.mapbox.accessToken = 'pk.eyJ1IjoiY29kZWZvcmFtZXJpY2EiLCJhIjoiSTZlTTZTcyJ9.3aSlHLNzvsTwK-CYfZsG_Q';
 
   // Create a map in the div #map
-  var map = L.mapbox.map('map', 'codeforamerica.map-hhckoiuj');
+  var map = L.mapbox.map('map', 'codeforamerica.map-hhckoiuj', {
+    tileLayer: false,
+  });
 
-  var geocoderControl = L.mapbox.geocoderControl('mapbox.places', { 
-    keepOpen: true, 
+  L.mapbox.styleLayer('mapbox://styles/mapbox/bright-v8')
+    .addTo(map);
+
+  var geocoderControl = L.mapbox.geocoderControl('mapbox.places', {
+    keepOpen: true,
     autocomplete : true,
     queryOptions: {
       country: "us"
@@ -26,7 +31,7 @@ window.Brigade.initializeMap = function(geoJSON) {
       $('#map input').val(result.feature.place_name);
       $('#map .leaflet-control-mapbox-geocoder-results').hide();
     });
-    
+
     // Make sure the geocoder results are showing when input is entered into geocoder search
     $('#map input').keyup(function(){
       $('#map .leaflet-control-mapbox-geocoder-results').show();


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/129120/36002923-c79d155e-0ce0-11e8-8624-0251990c04da.png)

After:
![screen shot 2018-02-07 at 11 10 14 am](https://user-images.githubusercontent.com/129120/35936241-85a12de6-0bf7-11e8-8040-5f24b41ebe7f.png)


The default mapbox styling uses a pure-white (#fff) background for land
areas. User feedback indicated that this makes the navigation controls
hard to see.

By removing the existing tileLayer and adding a "styleLayer" (a class
which extends tileLayer - see [1]), we can make the map a bit more
stylish with a theme that uses a grey for the countries. [Here's a list
of all public styles.][2]

[1]: https://www.mapbox.com/mapbox.js/api/v3.1.1/l-mapbox-stylelayer/
[2]: https://github.com/mapbox/mapbox-gl-styles