### PR TITLE
Add link to G Suite to software page

### DIFF
--- a/brigade/templates/free_software.html
+++ b/brigade/templates/free_software.html
@@ -72,6 +72,14 @@
         <p>Slack is a group communication tool built around chat.</p>
         <div class="button">Learn more</div>
       </a>
+
+      <a class="inkind-card" href="{{ url_for(".free_software_show", software="gsuite") }}">
+        <div class="inkind-card__logo">
+          <img src="{{ asset_url_for('images/software_gsuite.svg') }}" width="200px" />
+        </div>
+        <p>G Suite is Google's hosted product featuring Gmail, Google Drive, Groups, and more.</p>
+        <div class="button">Learn more</div>
+      </a>
     </div>
 
     <h2>Mapping Software</h2>


### PR DESCRIPTION
We're rolling out G Suite now to brigades. Let's add this to the
software page!