### PR TITLE
Small style adjustments to Alert component

### DIFF
--- a/brigade/static/scss/molecules/_alert.scss
+++ b/brigade/static/scss/molecules/_alert.scss
@@ -6,18 +6,23 @@
 
 .alert {
   background-color: $color-gray-light;
-}
-
-.alert,
-.alert-success, 
-.alert-failure, 
-.alert-pending, 
-.alert-None {
+  border-radius: 3px;
   border: 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 14px;
+  line-height: 1.5em;
+  padding: 1em;
 }
 
-.alert-pending, 
-.alert-None {
-  background-color: #e5e5e5;
-  margin: 0 0 16px 0;
+.alert__content {
+  flex: 1;
+}
+
+.alert__icon {
+  flex: 0 0 auto;
+  font-size: 1.5em;
+  line-height: 1;
+  opacity: 0.7;
+  padding-right: 0.5em;
 }

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -16,9 +16,14 @@
 <section class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-half">
-      <p class="alert">
-        <i class="fas fa-info-circle"></i> <strong>Looking for a brigade event?</strong> <a href="/">Use the map</a> to find your local brigade.
-      </p>
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fas fa-info-circle"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Looking for a brigade event?</strong> <a href="/">Use the map</a> to find your local brigade.
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This adds an `.alert__icon` element and displays it neatly alongside the alert content. Also makes some minor visual improvements.

Before: 
![image](https://user-images.githubusercontent.com/8628090/36821791-979eb6c2-1ca9-11e8-9ff2-436a3a3f4fe7.png)

After: 
![image](https://user-images.githubusercontent.com/8628090/36821809-acb88f4c-1ca9-11e8-9769-8472ec758598.png)
