### PR TITLE
Add 'start a new brigade' alert to homepage

### DIFF
--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -12,7 +12,16 @@ communities.{% endblock %}
         <img id="logo" src="{{ asset_url_for('images/the_brigade.png') }}" />
       </div>
       <div class="panel__body padding-top-none">
-        The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21st century, if we all help.
+        <p>The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21st century, if we all help.</p>
+        <div class="alert">
+          <div class="alert__icon">
+            <i class="fas fa-star"></i>
+          </div>
+          <div class="alert__content">
+            No brigade near you? <strong>Start a new brigade!</strong><br>
+            <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
+          </div>
+        </div>
       </div>
     </div>
     <div class="panel" id="map-panel">


### PR DESCRIPTION
It's not clear at the moment from the home page where to go to start a new brigade. This commit adds a little alert box with a link to the [Start a Brigade page](https://www.codeforamerica.org/how-tos-1/how-tos-start-a-brigade) on the CfA website, to help the user get started.

![image](https://user-images.githubusercontent.com/8628090/36918767-d138a584-1e0f-11e8-9566-cfa1b240d637.png)