### PR TITLE
Add Workshops and Meetings calendar to Events page

### DIFF
--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -13,6 +13,13 @@
   </div>
 </header>
 
+<nav class="slab slab--compact slab-gray">
+  <div class="grid-box">
+    <a href="#key-dates" class="button">Key Dates</a>
+    <a href="#workshops-and-meetings" class="button">Workshops and Meetings</a>
+  </div>
+</nav>
+
 <section class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-half">
@@ -31,8 +38,8 @@
 <section id="key-dates" class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-half">
-      <h2 class="section__title">Key Dates</h2>
-      <p class="section__subtitle">In 2018, brigades have an opportunity to participate in days of action and to come together at shared events. Check out the upcoming events and add them to your calendars.</p>
+      <h2 class="slab__title">Key Dates</h2>
+      <p class="slab__subtitle">In 2018, brigades have an opportunity to participate in days of action and to come together at shared events. Check out the upcoming events and add them to your calendars.</p>
       <ul class="list list--no-bullets list--expanded">
         <!-- <li>
           <h3>
@@ -61,10 +68,33 @@
           <h3><small>October, 2018</small> <br><strong>Brigade Congress</strong></h3>
           <p>
             This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the 21<sup>st</sup> century if we all build it together. (More details coming soon!)
-
           </p>
         </li>
       </ul>
+    </div>
+  </div>
+</section>
+
+<section id="workshops-and-meetings" class="slab slab-gray">
+  <div class="grid-box">
+    <div class="width-one-half">
+      <h2 class="slab__title">Workshops and Meetings</h2>
+      <ul>
+        <li>Code for America is helping build a network of civic technologists eager to share ideas and collaborate nationwide.</li>
+        <li>We host events like workshops, forums and meetings, to share knowledge, experiences and lessons learned.</li>
+        <li>All brigade members are encouraged to attend these events. To participate, check out the attached calendar.</li>
+      </ul>
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fas fa-question-circle"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Have a meeting or workshop to add to the calendar?</strong> <br>Let us know at <a href="mailto:brigade-info@codeforamerica.org">brigade-info@codeforamerica.org</a>
+        </div>
+      </div>
+    </div>
+    <div class="width-one-half">
+      <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=codeforamerica.org_e4fugvnjpk4b5fvgjfe916sa6g%40group.calendar.google.com&amp;color=%23182C57&amp;ctz=America%2FLos_Angeles" style="border:solid 1px #777" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This adds a new section with an embedded Google Calendar that includes
network-wide events like workshops and other meetings.

This also adds a page navigation for the two sections: Key Dates, and
Workshops and Meetings.