### PR TITLE
Add text listing of all brigades

### DIFF
--- a/brigade/sitemap.py
+++ b/brigade/sitemap.py
@@ -47,7 +47,7 @@ class SitemapBlueprint(Blueprint):
                 yield (route, {}, None, 'monthly', '0.5')
 
             brigades = get_brigades()
-            for brigade in json.loads(brigades):
+            for brigade in brigades:
                 last_updated = datetime.fromtimestamp(brigade['properties']['last_updated'])
 
                 for route in self.PER_BRIGADE_ROUTES:

--- a/brigade/static/scss/core/_utilities.scss
+++ b/brigade/static/scss/core/_utilities.scss
@@ -10,6 +10,35 @@
 }
 
 // Text alignment
-.text-center {
-  text-align: center;
+.text-left { text-align: left; }
+.text-right { text-align: right; }
+.text-center { text-align: center; }
+.text-justify { text-align: justify; }
+
+@media (min-width: $mobile-up) {
+  .text-left-mobile-up { text-align: left; }
+  .text-right-mobile-up { text-align: right; }
+  .text-center-mobile-up { text-align: center; }
+  .text-justify-mobile-up { text-align: justify; }
+}
+
+@media (min-width: $tablet-up) {
+  .text-left-tablet-up { text-align: left; }
+  .text-right-tablet-up { text-align: right; }
+  .text-center-tablet-up { text-align: center; }
+  .text-justify-tablet-up { text-align: justify; }
+}
+
+@media (min-width: $midscreen-up) {
+  .text-left-midscreen-up { text-align: left; }
+  .text-right-midscreen-up { text-align: right; }
+  .text-center-midscreen-up { text-align: center; }
+  .text-justify-midscreen-up { text-align: justify; }
+}
+
+@media (min-width: $widescreen-up) {
+  .text-left-widescreen-up { text-align: left; }
+  .text-right-widescreen-up { text-align: right; }
+  .text-center-widescreen-up { text-align: center; }
+  .text-justify-widescreen-up { text-align: justify; }
 }

--- a/brigade/static/scss/core/_utilities.scss
+++ b/brigade/static/scss/core/_utilities.scss
@@ -14,31 +14,3 @@
 .text-right { text-align: right; }
 .text-center { text-align: center; }
 .text-justify { text-align: justify; }
-
-@media (min-width: $mobile-up) {
-  .text-left-mobile-up { text-align: left; }
-  .text-right-mobile-up { text-align: right; }
-  .text-center-mobile-up { text-align: center; }
-  .text-justify-mobile-up { text-align: justify; }
-}
-
-@media (min-width: $tablet-up) {
-  .text-left-tablet-up { text-align: left; }
-  .text-right-tablet-up { text-align: right; }
-  .text-center-tablet-up { text-align: center; }
-  .text-justify-tablet-up { text-align: justify; }
-}
-
-@media (min-width: $midscreen-up) {
-  .text-left-midscreen-up { text-align: left; }
-  .text-right-midscreen-up { text-align: right; }
-  .text-center-midscreen-up { text-align: center; }
-  .text-justify-midscreen-up { text-align: justify; }
-}
-
-@media (min-width: $widescreen-up) {
-  .text-left-widescreen-up { text-align: left; }
-  .text-right-widescreen-up { text-align: right; }
-  .text-center-widescreen-up { text-align: center; }
-  .text-justify-widescreen-up { text-align: justify; }
-}

--- a/brigade/static/scss/molecules/_nav.scss
+++ b/brigade/static/scss/molecules/_nav.scss
@@ -6,6 +6,7 @@
 //
 
 .nav-global-secondary {
+  font-size: 14px;
   text-transform: none;
 
   li a { 

--- a/brigade/static/scss/pages/_brigade-list.scss
+++ b/brigade/static/scss/pages/_brigade-list.scss
@@ -1,0 +1,15 @@
+@import '../core/variables';
+@import '../core/mixins';
+
+//
+// Page: Brigade list
+//
+
+body#brigade-list {
+  /* On wide screens, right-align the state name */
+  @include media($tablet-up) {
+    .brigade-list__state {
+      text-align: right;      
+    }
+  }
+}

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -33,5 +33,6 @@
 @import 'templates/brigade-profile';
 
 // Pages
+@import 'pages/brigade-list';
 @import 'pages/home';
 @import 'pages/projects';

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -26,12 +26,13 @@
       </nav>
 
       <div class="global-header">
-        <a href="/brigade" class="global-header-logo">
+        <a href="/" class="global-header-logo">
             <img src="{{ asset_url_for('images/new_logo.png') }}" />
         </a>
 
         <nav class="nav-global-secondary">
           <ul>
+            <li><a href="{{url_for('brigade.brigade_list')}}">Find a Brigade</a></li>
             <li><a href="{{url_for('brigade.resources')}}">Resources</a></li>
             <li><a href="{{url_for('brigade.events')}}">Events</a></li>
             <li><a href="{{url_for('brigade.projects')}}">Project Finder</a></li>

--- a/brigade/templates/brigade_list.html
+++ b/brigade/templates/brigade_list.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
+
 {% block description %}
-communities.{% endblock %}
+Explore the {{ brigades_total }} official Code for America brigades across the US.
+{% endblock %}
 
 {% block page_id %}brigade-list{% endblock %}
 
@@ -28,18 +30,18 @@ communities.{% endblock %}
   </div>
 </div>
 
-{% for state in states|sort %}
-<section id="{{ states[state]['name'] }}" class="slab slab--compact">
+{% for state in brigades_by_state|sort %}
+<section id="{{ brigades_by_state[state]['name'] }}" class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-fourth">
       <h3 class="slab__heading text-right-tablet-up">{{ state }}</h3>
     </div>
     <div class="width-one-half">
       <ul class="list">
-      {% for brigade in states[state]|sort %}
+      {% for brigade in brigades_by_state[state] %}
         <li>
-          <a href="/brigades/{{ states[state][brigade]['id'] }}">{{ brigade }}</a><br>
-          <small>{{ states[state][brigade]['city'] }}</small>
+          <a href="{{ url_for('brigade.brigade', brigadeid=brigade['id']) }}">{{ brigade['name'] }}</a><br>
+          <small>{{ brigade['city'] }}</small>
         </li>
       {% endfor %}
       </ul>

--- a/brigade/templates/brigade_list.html
+++ b/brigade/templates/brigade_list.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block description %}
+communities.{% endblock %}
+
+{% block page_id %}brigade-list{% endblock %}
+
+{% block content %}
+
+<header class="page-header slab slab-dark-blue">
+  <div class="grid-box">
+    <h1 class="title">Find your local brigade</h1>
+    <div class="subtitle">Explore the {{ brigades_total }} official Code for America brigades across the US</div>
+  </div>
+</header>
+<div class="slab slab--compact">
+  <div class="grid-box">
+    <div class="width-two-thirds">
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fas fa-star"></i>
+        </div>
+        <div class="alert__content">
+          No brigade near you? <strong>Start a new brigade!</strong><br>
+          <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% for state in states|sort %}
+<section id="{{ states[state]['name'] }}" class="slab slab--compact">
+  <div class="grid-box">
+    <div class="width-one-fourth">
+      <h3 class="slab__heading text-right-tablet-up">{{ state }}</h3>
+    </div>
+    <div class="width-one-half">
+      <ul class="list">
+      {% for brigade in states[state]|sort %}
+        <li>
+          <a href="/brigades/{{ states[state][brigade]['id'] }}">{{ brigade }}</a><br>
+          <small>{{ states[state][brigade]['city'] }}</small>
+        </li>
+      {% endfor %}
+      </ul>
+    </div>
+  </div>
+</section>
+{% endfor %}
+
+{% endblock %}

--- a/brigade/templates/brigade_list.html
+++ b/brigade/templates/brigade_list.html
@@ -31,10 +31,10 @@ Explore the {{ brigades_total }} official Code for America brigades across the U
 </div>
 
 {% for state in brigades_by_state|sort %}
-<section id="{{ brigades_by_state[state]['name'] }}" class="slab slab--compact">
+<section id="{{ brigades_by_state[state]['name'] }}" class="brigade-list slab slab--compact">
   <div class="grid-box">
     <div class="width-one-fourth">
-      <h3 class="slab__heading text-right-tablet-up">{{ state }}</h3>
+      <h3 class="brigade-list__state slab__heading">{{ state }}</h3>
     </div>
     <div class="width-one-half">
       <ul class="list">

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -1,16 +1,15 @@
 # -- coding: utf-8 --
-from flask import render_template, request, redirect, url_for
-from flask.helpers import safe_join
-from . import brigade as app
 import cfapi
-from operator import itemgetter
-from requests import get
-from datetime import datetime
 import dateutil.parser
-
+import json
 import logging
 import urllib
-
+from . import brigade as app
+from datetime import datetime
+from flask import render_template, request, redirect, url_for
+from flask.helpers import safe_join
+from operator import itemgetter
+from requests import get
 
 # Logging Setup
 logging.basicConfig(level=logging.INFO)
@@ -39,6 +38,7 @@ def redirect_from(*urls):
 @app.route('/map')
 def map():
     brigades = cfapi.get_brigades(official_brigades_only=True)
+    brigades = json.dumps(brigades)
     return render_template("map.html", brigades=brigades)
 
 
@@ -300,4 +300,5 @@ def project_monitor(brigadeid=None):
 @app.route('/', methods=['GET'])
 def index():
     brigades = cfapi.get_brigades(official_brigades_only=True)
+    brigades = json.dumps(brigades)
     return render_template("index.html", brigades=brigades)

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -3,7 +3,6 @@ import cfapi
 import dateutil.parser
 import json
 import logging
-import re
 import urllib
 from . import brigade as app
 from datetime import datetime
@@ -303,89 +302,19 @@ def project_monitor(brigadeid=None):
     return render_template('monitor.html', projects=projects_with_tests, org_name=brigadeid)
 
 
-@redirect_from('/brigade/list', '/brigades/')
+@redirect_from('/brigade/list', '/brigades')
 @app.route('/brigades')
 def brigade_list():
-    state_names = {
-        'AK': 'Alaska',
-        'AL': 'Alabama',
-        'AR': 'Arkansas',
-        'AS': 'American Samoa',
-        'AZ': 'Arizona',
-        'CA': 'California',
-        'CO': 'Colorado',
-        'CT': 'Connecticut',
-        'DC': 'District of Columbia',
-        'DE': 'Delaware',
-        'FL': 'Florida',
-        'GA': 'Georgia',
-        'GU': 'Guam',
-        'HI': 'Hawaii',
-        'IA': 'Iowa',
-        'ID': 'Idaho',
-        'IL': 'Illinois',
-        'IN': 'Indiana',
-        'KS': 'Kansas',
-        'KY': 'Kentucky',
-        'LA': 'Louisiana',
-        'MA': 'Massachusetts',
-        'MD': 'Maryland',
-        'ME': 'Maine',
-        'MI': 'Michigan',
-        'MN': 'Minnesota',
-        'MO': 'Missouri',
-        'MP': 'Northern Mariana Islands',
-        'MS': 'Mississippi',
-        'MT': 'Montana',
-        'NA': 'National',
-        'NC': 'North Carolina',
-        'ND': 'North Dakota',
-        'NE': 'Nebraska',
-        'NH': 'New Hampshire',
-        'NJ': 'New Jersey',
-        'NM': 'New Mexico',
-        'NV': 'Nevada',
-        'NY': 'New York',
-        'OH': 'Ohio',
-        'OK': 'Oklahoma',
-        'OR': 'Oregon',
-        'PA': 'Pennsylvania',
-        'PR': 'Puerto Rico',
-        'RI': 'Rhode Island',
-        'SC': 'South Carolina',
-        'SD': 'South Dakota',
-        'TN': 'Tennessee',
-        'TX': 'Texas',
-        'UT': 'Utah',
-        'VA': 'Virginia',
-        'VI': 'Virgin Islands',
-        'VT': 'Vermont',
-        'WA': 'Washington',
-        'WI': 'Wisconsin',
-        'WV': 'West Virginia',
-        'WY': 'Wyoming'
-    }
-    states = {}
+    brigades_by_state = cfapi.get_official_brigades_by_state()
     brigades = cfapi.get_brigades(official_brigades_only=True)
     brigades_total = len(brigades)
-    # Find all two-letter state abbreviations in the brigade's city, and add brigade to those states
-    for brigade in brigades:
-        brigade_name = brigade['properties']['name']
-        brigade_properties = {
-            'id': brigade['properties']['id'],
-            'city': brigade['properties']['city']
-        }
-        brigade_states = re.findall(
-            r'\b([A-Z]{2})\b', brigade['properties']['city'])
-        for state in brigade_states:
-            state_fullname = state_names[state]
-            if state_fullname not in states:
-                states[state_fullname] = {}
-            states[state_fullname][brigade_name] = brigade_properties
-    return render_template("brigade_list.html", brigades_total=brigades_total, states=states)
+    return render_template(
+        "brigade_list.html",
+        brigades_total=brigades_total,
+        brigades_by_state=brigades_by_state)
 
 
-@redirect_from('/brigade/', '/brigade')
+@redirect_from('/brigade/')
 @app.route('/', methods=['GET'])
 def index():
     brigades = cfapi.get_brigades(official_brigades_only=True)

--- a/cfapi/__init__.py
+++ b/cfapi/__init__.py
@@ -1,7 +1,67 @@
-from requests import get
 import json
+import re
+from requests import get
 
 BASE_URL = "http://api.codeforamerica.org/api"
+STATE_NAMES = {
+    'AK': 'Alaska',
+    'AL': 'Alabama',
+    'AR': 'Arkansas',
+    'AS': 'American Samoa',
+    'AZ': 'Arizona',
+    'CA': 'California',
+    'CO': 'Colorado',
+    'CT': 'Connecticut',
+    'DC': 'District of Columbia',
+    'DE': 'Delaware',
+    'FL': 'Florida',
+    'GA': 'Georgia',
+    'GU': 'Guam',
+    'HI': 'Hawaii',
+    'IA': 'Iowa',
+    'ID': 'Idaho',
+    'IL': 'Illinois',
+    'IN': 'Indiana',
+    'KS': 'Kansas',
+    'KY': 'Kentucky',
+    'LA': 'Louisiana',
+    'MA': 'Massachusetts',
+    'MD': 'Maryland',
+    'ME': 'Maine',
+    'MI': 'Michigan',
+    'MN': 'Minnesota',
+    'MO': 'Missouri',
+    'MP': 'Northern Mariana Islands',
+    'MS': 'Mississippi',
+    'MT': 'Montana',
+    'NA': 'National',
+    'NC': 'North Carolina',
+    'ND': 'North Dakota',
+    'NE': 'Nebraska',
+    'NH': 'New Hampshire',
+    'NJ': 'New Jersey',
+    'NM': 'New Mexico',
+    'NV': 'Nevada',
+    'NY': 'New York',
+    'OH': 'Ohio',
+    'OK': 'Oklahoma',
+    'OR': 'Oregon',
+    'PA': 'Pennsylvania',
+    'PR': 'Puerto Rico',
+    'RI': 'Rhode Island',
+    'SC': 'South Carolina',
+    'SD': 'South Dakota',
+    'TN': 'Tennessee',
+    'TX': 'Texas',
+    'UT': 'Utah',
+    'VA': 'Virginia',
+    'VI': 'Virgin Islands',
+    'VT': 'Vermont',
+    'WA': 'Washington',
+    'WI': 'Wisconsin',
+    'WV': 'West Virginia',
+    'WY': 'Wyoming'
+}
 
 
 def get_brigades(official_brigades_only=False):
@@ -18,15 +78,32 @@ def get_brigades(official_brigades_only=False):
         org["properties"]["marker-color"] = "#aa1c3a"
         # Grab only orgs with type Brigade
         if ("tags" in org["properties"] and "Brigade" in org["properties"]["tags"]):
-            
+
             # If cfa_brigades_only=True, only return Official Brigades
-            if official_brigades_only == True:
+            if official_brigades_only:
                 if "Official" in org["properties"]["tags"]:
                     brigades.append(org)
             else:
                 brigades.append(org)
 
     return brigades
+
+
+def get_official_brigades_by_state():
+    brigades = get_brigades(official_brigades_only=True)
+    states = {}
+    # Find all two-letter state abbreviations in the brigade's city, and add brigade to those states
+    for brigade in brigades:
+        brigade_states = re.findall(
+            r'\b([A-Z]{2})\b', brigade['properties']['city'])
+        for state in brigade_states:
+            state_fullname = STATE_NAMES[state]
+            if state_fullname not in states:
+                states[state_fullname] = []
+            states[state_fullname].append(brigade['properties'])
+    for brigades in states.values():
+        brigades.sort(key=lambda b: b['name'])
+    return states
 
 
 # TODO: make a get_organization_projects wrapper so the URL doesn't need to be

--- a/cfapi/__init__.py
+++ b/cfapi/__init__.py
@@ -26,7 +26,6 @@ def get_brigades(official_brigades_only=False):
             else:
                 brigades.append(org)
 
-    brigades = json.dumps(brigades)
     return brigades
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,7 +29,29 @@ class BrigadeTests(unittest.TestCase):
         if url.geturl() == cfapi.BASE_URL + '/organizations/TEST-ORG':
             return httmock.response(200, '{"city": "San Francisco, CA", "type": "Brigade", "name": "Code for San Francisco"}') # noqa
         if url.geturl() == cfapi.BASE_URL + "/organizations.geojson":
-            return httmock.response(200, '{"features" : [{ "id": "TEST-ORG", "properties" : { "id" : "TEST-ORG", "tags" : ["Brigade"], "last_updated": 1510874211 } } ] }') # noqa
+            return httmock.response(200, '''
+                {
+                    "features" : [{ 
+                        "id": "TEST-ORG", 
+                        "properties" : { 
+                            "id": "TEST-ORG", 
+                            "name": "Test Org",
+                            "tags": ["Brigade", "Official", "Code for America"], 
+                            "last_updated": 1510874211,
+                            "city": "Oakland, CA"
+                        } 
+                    },
+                    { 
+                        "id": "Code-for-Atlantis",
+                        "properties" : { 
+                            "id": "Code-for-Atlantis", 
+                            "name": "Code for Atlantis",
+                            "tags": ["Brigade", "Official", "Code for America"], 
+                            "last_updated": 1510874211,
+                            "city": "Atlantis, GA"
+                        } 
+                    }]
+                }''') # noqa
         if url.geturl() == cfapi.BASE_URL + "/projects/1":
             return httmock.response(200, '''
                 {
@@ -170,6 +192,14 @@ class BrigadeTests(unittest.TestCase):
         test_time = "2018-12-25 18:30:00 -0800"
         formatted_time = format_time(test_time)
         self.assertEqual(formatted_time, "Tuesday, Dec 25, 2018 @ 6:30 PM")
+
+    def test_get_official_brigades_by_state(self):
+        with httmock.HTTMock(self.response_content):
+            from cfapi import get_official_brigades_by_state
+            brigades = get_official_brigades_by_state()
+            self.assertEqual(len(brigades), 2)
+            self.assertIn("Georgia", brigades)
+            self.assertEquals(brigades["Georgia"][0]['id'], "Code-for-Atlantis")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
At the moment, the only way to navigate to a brigade profile is through
the map on the home page. During earlier user testing, some participants
mentioned that they would prefer to use a text listing of the brigades
for navigation, or struggled to use the map.

This adds a new page with a text listing of all the official brigades.
Brigades are grouped by State and displayed alphabetically. The State
abbreviation for each brigade is inferred from its `city` property. When
the City spans two states, as is the case with Code for Kansas City,
it is displayed under both states -- i.e. Kansas and Missouri.