### PR TITLE
Fix typo with BRigade Congress description

### DIFF
--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -61,13 +61,13 @@
         <li>
           <h3><small>August 11, 2018</small> <br><strong>National Day of Civic Hacking</strong></h3>
           <p>
-            This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the 21<sup>st</sup> century if we all build it together.
+            This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the 21<sup>st</sup> century if we all build it together. (More details coming soon!)
           </p>
         </li>
         <li>
           <h3><small>October, 2018</small> <br><strong>Brigade Congress</strong></h3>
           <p>
-            This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the 21<sup>st</sup> century if we all build it together. (More details coming soon!)
+            Brigade Congress is an annual unconference where brigade participants share stories on what has worked, what hasn't, and how we can apply to those lessons to future wins. (More details coming soon!)
           </p>
         </li>
       </ul>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -67,7 +67,7 @@
         <li>
           <h3><small>October, 2018</small> <br><strong>Brigade Congress</strong></h3>
           <p>
-            Brigade Congress is an annual unconference where brigade participants share stories on what has worked, what hasn't, and how we can apply to those lessons to future wins. (More details coming soon!)
+            Brigade Congress is an annual unconference where brigade participants share stories on what has worked, what hasn't, and how we can apply those lessons to future wins. (More details coming soon!)
           </p>
         </li>
       </ul>


### PR DESCRIPTION
This adds the correct description.