### PR TITLE
Fix homepage hero banner so it displays properly at all screen widths

### DIFF
--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -96,11 +96,6 @@ window.Brigade.initializeProjects = function(id, query, status) {
 };
 
 window.Brigade.init = function() {
-  // Generate list of brigades
-  if ($(window).width() > 480){
-    $('body#home #overview').css("height", ($(window).height() - $(".global-header").height()));
-  }
-
   // Track all link clicks as explicit events.
   //
   // The event's label will be given by either the <a title> attribute or the

--- a/brigade/static/scss/pages/_home.scss
+++ b/brigade/static/scss/pages/_home.scss
@@ -5,19 +5,45 @@
 // Page: Home
 //
 
-body#home {
+.home-hero {
+  min-height: 300px;
 
-  .home-hero {
-    min-height: 300px;
+  @include media($tablet-up) {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.home-hero__content {
+  padding: 20px;
+
+  @include media($tablet-up) {
+    flex: 1;
+  }
+}
+
+.home-hero__map {
+  border-bottom: solid 1px $color-border-dark;
+
+  @include media($tablet-up) {
+    display: flex;
+    flex: 2;
+    flex-direction: column;
   }
 
-  .home-hero__content {
-    padding: 20px;
+  .panel__body {
+    padding: 0;
+
+    @include media($tablet-up) {
+      flex: 1;
+    }
   }
 
-  .home-hero__map {
-    border-bottom: solid 1px $color-border-dark;
-    .panel__body { padding: 0; }
+  .panel__footer {
+    @include media($tablet-up) {
+      flex: 0;
+      text-align: right;
+    }
   }
 
   #map {
@@ -25,33 +51,16 @@ body#home {
     min-height: 300px;
     min-height: 80vh;
 
-    input { min-height: 0; }
-
-    .leaflet-marker-icon { cursor: pointer !important; }
-
-    .leaflet-popup-close-button { display: none; }
-  }
-
-  // Styling for wider screens
-  @include media($tablet-up) {
-    .home-hero {
-      display: flex;
-      flex-direction: row;
+    input {
+      min-height: 0;
     }
 
-    .home-hero__content { flex: 1; }
+    .leaflet-marker-icon {
+      cursor: pointer !important;
+    }
 
-    .home-hero__map {
-      display: flex;
-      flex: 2;
-      flex-direction: column;
-
-      .panel__body { flex: 1; }
-
-      .panel__footer {
-        flex: 0;
-        text-align: right;
-      }
+    .leaflet-popup-close-button {
+      display: none;
     }
   }
 }

--- a/brigade/static/scss/pages/_home.scss
+++ b/brigade/static/scss/pages/_home.scss
@@ -1,4 +1,5 @@
 @import '../core/variables';
+@import '../core/mixins';
 
 //
 // Page: Home
@@ -6,63 +7,51 @@
 
 body#home {
 
-  #intro-panel {
+  .home-hero {
     min-height: 300px;
   }
 
-   #map-panel {
-    border-bottom: solid 1px $color-border-dark;  
+  .home-hero__content {
+    padding: 20px;
   }
 
-  #map-panel .panel__body {
-    padding: 0;
+  .home-hero__map {
+    border-bottom: solid 1px $color-border-dark;
+    .panel__body { padding: 0; }
   }
 
   #map {
     height: 100%;
     min-height: 300px;
     min-height: 80vh;
+
+    input { min-height: 0; }
+
+    .leaflet-marker-icon { cursor: pointer !important; }
+
+    .leaflet-popup-close-button { display: none; }
   }
 
-  #map .leaflet-marker-icon {
-    cursor: pointer !important;
-  }
-
-  #map input {
-    min-height: 0;
-  }
-
-  #map .leaflet-popup-close-button {
-    display: none;
-  }
-
-  @media all and (min-width: 736px) {
-    
-    #overview {
-      height: 691px;
+  // Styling for wider screens
+  @include media($tablet-up) {
+    .home-hero {
       display: flex;
       flex-direction: row;
     }
 
-    #intro-panel {
-      flex: 1;
-    }
+    .home-hero__content { flex: 1; }
 
-    #map-panel {
-      flex: 2;
+    .home-hero__map {
       display: flex;
+      flex: 2;
       flex-direction: column;
-    }
 
-    #map-panel .panel__body {
-      flex: 1;
-    }
+      .panel__body { flex: 1; }
 
-    #map-panel .panel__footer {
-      flex: 0;
-      text-align: right;
+      .panel__footer {
+        flex: 0;
+        text-align: right;
+      }
     }
-
   }
-
 }

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -5,47 +5,45 @@ communities.{% endblock %}
 {% block page_id %}home{% endblock %}
 
 {% block content %}
-  
-  <section id="overview" class="slab slab--no-padding">
-    <div class="panel panel--primary" id="intro-panel">
-      <div class="panel__header">
-        <img id="logo" src="{{ asset_url_for('images/the_brigade.png') }}" />
+
+<section id="overview" class="home-hero slab slab--no-padding">
+  <div class="home-hero__content panel panel--primary">
+    <img id="logo" src="{{ asset_url_for('images/the_brigade.png') }}" />
+    <p>
+      The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21st century, if we all help.
+    </p>
+    <div class="alert">
+      <div class="alert__icon">
+        <i class="fas fa-star"></i>
       </div>
-      <div class="panel__body padding-top-none">
-        <p>The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21st century, if we all help.</p>
-        <div class="alert">
-          <div class="alert__icon">
-            <i class="fas fa-star"></i>
-          </div>
-          <div class="alert__content">
-            No brigade near you? <strong>Start a new brigade!</strong><br>
-            <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
-          </div>
-        </div>
+      <div class="alert__content">
+        No brigade near you? <strong>Start a new brigade!</strong><br>
+        <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
       </div>
     </div>
-    <div class="panel" id="map-panel">
-      <div class="panel__body">
-        <div id="map"></div>
-      </div>
-      <div class="panel__footer">
-        Looking for an organization outside the US? <a href="https://codeforall.org/" target="_blank" class="no-wrap">Check out the <strong>Code for All</strong> Network</a>
-      </div>
+  </div>
+  <div class="home-hero__map panel">
+    <div class="panel__body">
+      <div id="map"></div>
     </div>
-  </section>
-  
-  <section id="sponsors">
-    <div class="panel">
-      <div class="panel__body layout-centered">
-        <h4>Funders</h4>
-        <ul class="list list--inline">
-          <li><a href="https://www.rallydev.com/about/rally-for-impact" target="_blank"><img src="{{ asset_url_for('images/CAlogo.png') }}" height="60px"></a></li>
-          <li><a href="https://www.esri.com/" target="_blank"><img src="{{ asset_url_for('images/logo_esri.png') }}" height="60px"></a></li>
-          <li><a href="https://knightfoundation.org/" target="_blank"><img src="{{ asset_url_for('images/logo_knightfoundation.png') }}" height="60px"></a></li>
-        </ul>
-      </div>
-    </div>    
-  </section>
+    <div class="panel__footer">
+      Looking for an organization outside the US? <a href="https://codeforall.org/" target="_blank" class="no-wrap">Check out the <strong>Code for All</strong> Network</a>
+    </div>
+  </div>
+</section>
+
+<section id="sponsors">
+  <div class="panel">
+    <div class="panel__body layout-centered">
+      <h4>Funders</h4>
+      <ul class="list list--inline">
+        <li><a href="https://www.rallydev.com/about/rally-for-impact" target="_blank"><img src="{{ asset_url_for('images/CAlogo.png') }}" height="60"></a></li>
+        <li><a href="https://www.esri.com/" target="_blank"><img src="{{ asset_url_for('images/logo_esri.png') }}" height="60"></a></li>
+        <li><a href="https://knightfoundation.org/" target="_blank"><img src="{{ asset_url_for('images/logo_knightfoundation.png') }}" height="60"></a></li>
+      </ul>
+    </div>
+  </div>    
+</section>
 
 {% endblock %}
 


### PR DESCRIPTION
At certain screen widths, the homepage 'hero' banner rendered poorly with some strange clearfix issues and overlapping content.

![homepage-bug](https://user-images.githubusercontent.com/8628090/37686200-95220f0c-2c53-11e8-9e5b-cf5ff39ddcc0.png)

This commit removes the Javascript that made the map take up the full screen height and makes changes to the homepage styling to render the hero banner neatly using flexbox.

We're planning some big changes to the homepage in the near-future, so this is a quick-fix right now to get things to render properly and not break at certain screen widths.