### PR TITLE
Add "Past Events" section with some workshop links

### DIFF
--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -17,6 +17,7 @@
   <div class="grid-box">
     <a href="#key-dates" class="button">Key Dates</a>
     <a href="#workshops-and-meetings" class="button">Workshops and Meetings</a>
+    <a href="#past-events" class="button">Past Events</a>
   </div>
 </nav>
 
@@ -98,5 +99,31 @@
     </div>
   </div>
 </section>
+
+<section id="past-events" class="slab">
+  <div class="grid-box">
+    <div class="width-one-half">
+      <h2 class="slab__title">Past Events</h2>
+
+      <p>Many national events are recorded and posted on <a href="https://www.youtube.com/codeforamerica" target="_blank">Code for America's YouTube</a>. Here are a few of the most recent workshops and events:</p>
+
+      <ul class="list--expanded">
+        <li>
+          April 9, 2018</br>
+          <a href="https://medium.com/@veronicajyoung/the-code-for-america-network-shares-food-security-projects-ce8be1b17822" target="_blank">Food Security Projects Workshop</a>
+        </li>
+        <li>
+          March 7, 2018</br>
+          <a href="https://medium.com/code-for-america/brigades-discuss-tactics-for-how-to-host-a-demo-day-d5199cd2687b" target="_blank">Hosting a Demo Day Workshop</a>
+        </li>
+        <li>
+          February 21, 2018</br>
+          <a href="https://medium.com/code-for-america/brigades-share-their-favorite-fundraising-strategies-5c33262ea6e6" target="_blank">Fundraising Strategy Workshop</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
 
 {% endblock %}

--- a/brigade/templates/styleguide.html
+++ b/brigade/templates/styleguide.html
@@ -209,8 +209,42 @@
       </div>
     </div>
   </div>
+</section>
 
-</div>
+<section>
+  <div class="layout-semibreve">
+    <h2>Lists</h2>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Unstyled</h3>
+
+    <ul>
+      <li>Item one</li>
+      <li>Item 2</li>
+      <li>Item three</li>
+    </ul>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Variant: inline</h3>
+
+    <ul class="list--inline">
+      <li>Foo</li>
+      <li>Bar baz</li>
+      <li>One more item</li>
+    </ul>
+  </div>
+
+  <div class="layout-semibreve">
+    <h3>Variant: expanded</h3>
+
+    <ul class="list--expanded">
+      <li>Foo</li>
+      <li>Bar baz</li>
+      <li>One more item</li>
+    </ul>
+  </div>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
As a brigade leader looking to learn something from an event that has
already happened, I should be able to find videos from previous
workshops and other events.

It seems reasonable to me to put this content on the Events page, but I
will user test it before merging.