### PR TITLE
Revert "Add Community Fellowship pre-header message"

### DIFF
--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -21,15 +21,9 @@
   <body id="{% block page_id %}{% endblock %}">
 
     <div class="js-container">
-      <div class="global-header global-header--above">
-        <a href="https://www.codeforamerica.org/fellowship" target="_blank">
-          Want to improve your community? Apply for the
-          <span class="global-header__above-underline">
-            Code for America Community Fellowship
-          </span>
-          by April 30th.
-        </a>
-      </div>
+
+      <nav class="nav-global-primary">
+      </nav>
 
       <div class="global-header">
         <a href="/" class="global-header-logo">


### PR DESCRIPTION
This reverts commit 4c229c5724f8bdc6d70f18b6861f9fad7d74f551.

Applications for the fellowship are over now -- we can remove the
pre-header message!