### PR TITLE
Fix tests by importing correct package

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,7 @@
 import sys
 from os import environ, path
 from brigade import create_app
-from flask.ext.script import Manager, Server
+from flask_script import Manager, Server
 
 # grab environment variables from the .env file if it exists
 if path.exists('.env'):


### PR DESCRIPTION
This had been causing a deprecation warning for some time. Switching out
the import to match the current documentation on
https://flask-script.readthedocs.io/en/latest/ seems to do the trick.