### PR TITLE
Improve Webpack error message

### DIFF
--- a/brigade/__init__.py
+++ b/brigade/__init__.py
@@ -7,12 +7,20 @@ from sitemap import sitemap_blueprint
 
 brigade = Blueprint('brigade', __name__)
 
+def detect_webpack_manifest_path(expected_path):
+    path = os.path.abspath(expected_path)
+    if os.path.exists(path):
+        return path
+    else:
+        raise Exception("Webpack Build Missing -- Make sure webpack is running. " \
+                "Start it with `webpack --watch`")
+
 
 def create_app():
     app = Flask(__name__, static_folder='build/public/', static_url_path='/assets')
     app.config['SECRET_KEY'] = 'sekrit!'
+    app.config['WEBPACK_MANIFEST_PATH'] = detect_webpack_manifest_path('./brigade/build/manifest.json')
 
-    app.config['WEBPACK_MANIFEST_PATH'] = os.path.abspath('./brigade/build/manifest.json')
     webpack = Webpack()
     webpack.init_app(app)
 


### PR DESCRIPTION
If the Webpack build manifest file is missing, we can give a better
error message telling the developer to start webpack. (The error it
replaces, instructs the developer to set the WEBPACK_MANIFEST_PATH
environment variable.)