### PR TITLE
Add a Project Showcase page

### DIFF
--- a/brigade/static/scss/core/_base.scss
+++ b/brigade/static/scss/core/_base.scss
@@ -18,3 +18,7 @@ section {
   float: none;
   width: auto;
 }
+
+hr {
+  margin: 32px 0;
+}

--- a/brigade/static/scss/molecules/_alert.scss
+++ b/brigade/static/scss/molecules/_alert.scss
@@ -26,3 +26,9 @@
   opacity: 0.7;
   padding-right: 0.5em;
 }
+
+.alert--reverse {
+  background: none;
+  border: solid 1px #fff;
+  color: #fff;
+}

--- a/brigade/static/scss/molecules/_card.scss
+++ b/brigade/static/scss/molecules/_card.scss
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   font-weight: inherit;
-  margin: 15px 0;
+  margin-bottom: 30px;
 
   &:hover {
     box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);

--- a/brigade/static/scss/molecules/_list-group.scss
+++ b/brigade/static/scss/molecules/_list-group.scss
@@ -1,0 +1,45 @@
+@import '../core/variables';
+@import '../core/mixins';
+@import '../atoms/button';
+
+//
+// List Group
+//
+
+.list-group {
+  font-size: 0.9em;
+  line-height: 1.4;
+  text-align: center;
+
+  @include media($tablet-up) {
+    line-height: 30px;
+    text-align: left;
+  }
+}
+
+.list-group__list-item {
+  background-color: $color-gray-light;
+  margin-bottom: 10px;
+  overflow: auto;
+  padding: 10px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.list-group .list-item__actions {
+  margin-top: 10px;
+
+  a.button:link {
+    margin: 0;
+    height: auto;
+    line-height: 30px;
+    padding: 0 15px;
+  }
+
+  @include media($tablet-up) {
+    float: right;
+    margin-top: 0;
+  }
+}

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -20,6 +20,7 @@
 @import 'molecules/button-page-separator';
 @import 'molecules/card';
 @import 'molecules/inkind-card';
+@import 'molecules/list-group';
 @import 'molecules/nav';
 @import 'molecules/panel';
 @import 'molecules/searchbar';

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -35,7 +35,7 @@
             <li><a href="{{url_for('brigade.brigade_list')}}">Find a Brigade</a></li>
             <li><a href="{{url_for('brigade.resources')}}">Resources</a></li>
             <li><a href="{{url_for('brigade.events')}}">Events</a></li>
-            <li><a href="{{url_for('brigade.projects')}}">Project Finder</a></li>
+            <li><a href="{{url_for('brigade.project_showcase')}}">Project Showcase</a></li>
             <li><a href="{{url_for('brigade.about')}}">About Us</a></li>
             <li><a href="http://slack.codeforamerica.org" target="_blank" title="Slack sign-up form">Join us on Slack</a></li>
           </ul>

--- a/brigade/templates/brigade.html
+++ b/brigade/templates/brigade.html
@@ -254,6 +254,20 @@
   </div>
 
   <div class="grid-box">
+    <div class="width-three-fourths">
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fas fa-star"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Looking for project inspiration?</strong> 
+          <a href="{{url_for('brigade.project_showcase')}}">Check out the Brigade Project Showcase!</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-box">
     {% for project in brigade.current_projects %}
     <div class="width-one-fourth">
       <div class="card">

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -65,13 +65,13 @@
           <p>Court Bot gives residents easy-to-understand information about resolving citations and timely reminders about upcoming court dates.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>CourtBot</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Tulsa/">Code for Tulsa</a></span>
+              <strong>CourtBot</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Tulsa') }}">Code for Tulsa</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/codefortulsa/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
               </div>
             </div>
             <div class="list-group__list-item">
-              <strong>CourtBot</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Atlanta/">Code for Atlanta</a></span>
+              <strong>CourtBot</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Atlanta') }}">Code for Atlanta</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/codeforatlanta/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
               </div>
@@ -85,7 +85,7 @@
           <p>The Buncombe County ReEntry Resources Hub is a website providing high-quality information and resources to residents reentering society after a period of incarceration, as well as those dealing with the consequences of a previous conviction.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>Buncombe County ReEntry Resources</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Greensboro/">Code for Greensboro</a></span>
+              <strong>Buncombe County ReEntry Resources</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Greensboro') }}">Code for Greensboro</a></span>
               <div class="list-item__actions">
                 <a href="http://www.buncombereentryhub.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
@@ -105,7 +105,7 @@
           <p>Food for Thought is a searchable map and directory of where you can find no-cost summer meals for kids in Oklahoma.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>Food for Thought</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Tulsa/">Code for Tulsa</a></span>
+              <strong>Food for Thought</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Tulsa') }}">Code for Tulsa</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/codefortulsa/food4thought" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="https://summer-meals.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
@@ -120,7 +120,7 @@
           <p>Food Oasis LA (FOLA) shows you places to find healthy food in Los Angeles, whether you are looking to buy, grow, or need access to free food.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>Food Oasis LA</strong> <span class="no-wrap">by <a href="/brigades/Hack-for-LA/">Hack for LA</a></span>
+              <strong>Food Oasis LA</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Hack-for-LA') }}">Hack for LA</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/foodoasisla" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="https://foodoasis.la" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
@@ -135,7 +135,7 @@
           <p>Near Green is a web application that aims to make healthy food accessible to the city of Philadelphia.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>NearGreen</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Philly/">Code for Philly</a></span>
+              <strong>NearGreen</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Philly') }}">Code for Philly</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/CodeForPhilly/neargreen" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="https://codeforphilly.github.io/neargreen/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
@@ -167,7 +167,7 @@
           <p>CyclePhilly is a smartphone app for recording your bicycle trips. Data from the app can be used by regional transportation planners in the Philadelphia area to make Philly a better place to ride.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>CyclePhilly</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Philly/">Code for Philly</a></span>
+              <strong>CyclePhilly</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Philly') }}">Code for Philly</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/CodeForPhilly/cyclephilly" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="http://www.cyclephilly.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
@@ -188,14 +188,14 @@
           <p>Adopt a Drain Program enables residents to “adopt” a storm drain in their city or town, keeping it free of debris. While helping to reduce localized flooding, the program also fosters community engagement by encouraging residents to take an active role in improving their neighborhood.</p>
           <div class="list-group">
             <div class="list-group__list-item">
-              <strong>Adopt a Drain SF</strong> <span class="no-wrap">by <a href="/brigades/Code-for-San-Francisco/">Code for San Francisco</a></span>
+              <strong>Adopt a Drain SF</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-San-Francisco') }}">Code for San Francisco</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/sfbrigade/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="https://adoptadrain.sfwater.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
             <div class="list-group__list-item">
-              <strong>Norfolk Drains</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Hampton-Roads/">Code for Hampton Roads</a></span>
+              <strong>Norfolk Drains</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Hampton-Roads') }}">Code for Hampton Roads</a></span>
               <div class="list-item__actions">
                 <a href="https://github.com/Code4HR/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
                 <a href="https://norfolkdrains.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -1,0 +1,211 @@
+{% extends "base.html" %}
+{% block title %}Project Showcase{% endblock %}
+{% block description %}Explore some of the amazing work done by Brigades and find inspiration for your next project{% endblock %}
+
+{% block page_id %}events{% endblock %}
+
+{% block content %}
+
+<header id="intro" class="page-header slab slab-dark-blue">
+  <div class="grid-box">
+    <div class="width-two-thirds">
+      <h1 class="title">Project Showcase</h1>
+      <div class="subtitle">Explore amazing Brigade projects and adapt them for your local community.</div>
+    </div>
+    <div class="width-one-third">
+      <div class="alert alert--reverse">
+        <div class="alert__icon">
+          <i class="fas fa-star"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Know an amazing Brigade project that should be on this page?</strong><br> 
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLScYO3puRDGeE0728WrlQtgr8d1AoryytTGYBcahVgfHHhCX4w/viewform?usp=sf_link" target="_blank">Let us know!</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<section id="overview" class="slab slab--compact slab-gray">
+  <div class="grid-box">
+    <div class="width-two-thirds">
+      <p>
+        Showcase projects <strong>serve the public good</strong>, have clear goals that are <strong>aligned with the values of the Network</strong>, and are <strong>redeployable</strong>, with clean code and good documentation.
+      </p>
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fab fa-github"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Looking for the Civic Tech Github Project Search?</strong> 
+          <a href="{{url_for('brigade.projects')}}">Find it here!</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<nav class="slab slab--compact">
+  <div class="grid-box">
+    <h4>Explore by category:</h4>
+    <a href="#safety-and-justice" class="button-s">Safety and Justice</a>
+    <a href="#food-security" class="button-s">Food Security</a>
+    <a href="#transportation" class="button-s">Transportation</a>
+    <a href="#public-works" class="button-s">Public Works</a>
+  </div>
+</nav>
+
+<section class="slab slab-gray border-bottom border-bottom">
+  <div class="grid-box" id="safety-and-justice">
+    <div class="width-two-thirds">
+      <h2>Safety and Justice</h2>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Courtbot</h3>
+          <p>Court Bot gives residents easy-to-understand information about resolving citations and timely reminders about upcoming court dates.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>CourtBot</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Tulsa/">Code for Tulsa</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/codefortulsa/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+              </div>
+            </div>
+            <div class="list-group__list-item">
+              <strong>CourtBot</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Atlanta/">Code for Atlanta</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/codeforatlanta/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Reentry Resources Hub</h3>
+          <p>The Buncombe County ReEntry Resources Hub is a website providing high-quality information and resources to residents reentering society after a period of incarceration, as well as those dealing with the consequences of a previous conviction.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Buncombe County ReEntry Resources</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Greensboro/">Code for Greensboro</a></span>
+              <div class="list-item__actions">
+                <a href="http://www.buncombereentryhub.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid-box"><hr></div>
+  <div class="grid-box" id="food-security">
+    <h2>Food Security</h2>
+    <div class="width-two-thirds">
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Food for Thought (Summer Meals)</h3>
+          <p>Food for Thought is a searchable map and directory of where you can find no-cost summer meals for kids in Oklahoma.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Food for Thought</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Tulsa/">Code for Tulsa</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/codefortulsa/food4thought" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://summer-meals.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Food Oasis</h3>
+          <p>Food Oasis LA (FOLA) shows you places to find healthy food in Los Angeles, whether you are looking to buy, grow, or need access to free food.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Food Oasis LA</strong> <span class="no-wrap">by <a href="/brigades/Hack-for-LA/">Hack for LA</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/foodoasisla" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://foodoasis.la" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">NearGreen</h3>
+          <p>Near Green is a web application that aims to make healthy food accessible to the city of Philadelphia.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>NearGreen</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Philly/">Code for Philly</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/CodeForPhilly/neargreen" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://codeforphilly.github.io/neargreen/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="width-one-third">
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fab fa-youtube"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Want to learn more about food security projects in the Network?</strong><br> 
+          <a href="https://www.youtube.com/watch?v=jvVZHmMmq9I">Watch the Brigade Food Security Workshop video!</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid-box"><hr></div>
+  <div class="grid-box" id="transportation">
+    <div class="width-two-thirds">
+      <h2>Transportation</h2>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">CyclePhilly</h3>
+          <p>CyclePhilly is a smartphone app for recording your bicycle trips. Data from the app can be used by regional transportation planners in the Philadelphia area to make Philly a better place to ride.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>CyclePhilly</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Philly/">Code for Philly</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/CodeForPhilly/cyclephilly" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="http://www.cyclephilly.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid-box"><hr></div>
+  <div class="grid-box" id="public-works">
+    <div class="width-two-thirds">
+      <h2>Public Works</h2>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Adopt a Drain</h3>
+          <p>Adopt a Drain Program enables residents to “adopt” a storm drain in their city or town, keeping it free of debris. While helping to reduce localized flooding, the program also fosters community engagement by encouraging residents to take an active role in improving their neighborhood.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Adopt a Drain SF</strong> <span class="no-wrap">by <a href="/brigades/Code-for-San-Francisco/">Code for San Francisco</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/sfbrigade/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://adoptadrain.sfwater.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+            <div class="list-group__list-item">
+              <strong>Norfolk Drains</strong> <span class="no-wrap">by <a href="/brigades/Code-for-Hampton-Roads/">Code for Hampton Roads</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/Code4HR/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://norfolkdrains.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -106,6 +106,11 @@ def styleguide():
     return render_template("styleguide.html")
 
 
+@app.route("/showcase")
+def project_showcase():
+    return render_template("project_showcase.html")
+
+
 def brigade_projects(brigadeid=None):
     return redirect(url_for('.projects', brigadeid=brigadeid), code=301)
 


### PR DESCRIPTION
We want to add a new Project Showcase page to show off exemplar projects from across the Network that demonstrate a commitment to Code for America's values, clean code, and good documentation. This adds a simple version of the new page as an MVP, and has been through a few rounds of user testing. This should be a good starting point that we can continue iterating over and adding additional projects to.