### PR TITLE
Add housing section to Project Showcase

### DIFF
--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -98,8 +98,8 @@
   </div>
   <div class="grid-box"><hr></div>
   <div class="grid-box" id="housing">
+    <h2>Housing</h2>
     <div class="width-two-thirds">
-      <h2>Housing</h2>
       <div class="card">
         <div class="card__body">
           <h3 class="card__title">Housing Insights</h3>
@@ -128,6 +128,17 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+    <div class="width-one-third">
+      <div class="alert">
+        <div class="alert__icon">
+          <i class="fab fa-youtube"></i>
+        </div>
+        <div class="alert__content">
+          <strong>Want to learn more about housing projects in the Network?</strong><br> 
+          <a href="https://www.youtube.com/watch?v=xUL0EcGFCCY">Watch the Housing Workshop video!</a>
         </div>
       </div>
     </div>

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -141,6 +141,7 @@
           <a href="https://www.youtube.com/watch?v=xUL0EcGFCCY">Watch the Housing Workshop video!</a>
         </div>
       </div>
+      <iframe width="100%" height="200" src="https://www.youtube.com/embed/xUL0EcGFCCY" frameborder="0" allow="encrypted-media" allowfullscreen></iframe>
     </div>
   </div>
   <div class="grid-box"><hr></div>
@@ -203,6 +204,7 @@
           <a href="https://www.youtube.com/watch?v=jvVZHmMmq9I">Watch the Brigade Food Security Workshop video!</a>
         </div>
       </div>
+      <iframe width="100%" height="250" src="https://www.youtube.com/embed/jvVZHmMmq9I" frameborder="0" allow="encrypted-media" allowfullscreen></iframe>
     </div>
   </div>
   <div class="grid-box"><hr></div>

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -49,6 +49,7 @@
   <div class="grid-box">
     <h4>Explore by category:</h4>
     <a href="#safety-and-justice" class="button-s">Safety and Justice</a>
+    <a href="#housing" class="button-s">Housing</a>
     <a href="#food-security" class="button-s">Food Security</a>
     <a href="#transportation" class="button-s">Transportation</a>
     <a href="#public-works" class="button-s">Public Works</a>
@@ -88,6 +89,27 @@
               <strong>Buncombe County ReEntry Resources</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Greensboro') }}">Code for Greensboro</a></span>
               <div class="list-item__actions">
                 <a href="http://www.buncombereentryhub.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid-box"><hr></div>
+  <div class="grid-box" id="housing">
+    <div class="width-two-thirds">
+      <h2>Housing</h2>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Housing Insights</h3>
+          <p>Housing Insights assembles essential information on subsidized affordable housing and connects it to relevant outside data, to support the work of the affordable housing community and decision makers.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Housing Insights</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-DC') }}">Code for DC</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/codefordc/housing-insights" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="http://housinginsights.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -115,6 +115,21 @@
           </div>
         </div>
       </div>
+      <div class="card">
+        <div class="card__body">
+          <h3 class="card__title">Renter's Rights Guide</h3>
+          <p>Renter's Rights Guide is a web application to help renters understand the laws and programs in place to protect them.</p>
+          <div class="list-group">
+            <div class="list-group__list-item">
+              <strong>Renter's Rights Guide</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-San-Jose') }}">Code for San Jose</a></span>
+              <div class="list-item__actions">
+                <a href="https://github.com/codeforsanjose/renters-rights" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://rentersrightsguide.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div class="grid-box"><hr></div>


### PR DESCRIPTION
This PR adds some example housing projects to the showcase, and links to the Brigade Housing project workshop video on Youtube. 

It also embeds the two brigade projects workshop Youtube videos on the Project Showcase page.