### PR TITLE
Rename 'alert' component to 'message'

### DIFF
--- a/brigade/static/scss/molecules/_message.scss
+++ b/brigade/static/scss/molecules/_message.scss
@@ -1,13 +1,13 @@
 @import '../core/variables';
 
 //
-// Alert
+// Message
 //
 
-.alert-info {
+.message {
   background-color: $color-gray-light;
-  border-radius: 3px;
   border: 0;
+  border-radius: 3px;
   display: flex;
   flex-direction: row;
   font-size: 14px;
@@ -15,20 +15,20 @@
   padding: 1em;
 }
 
-.alert-info__content {
+.message__content {
   flex: 1;
 }
 
-.alert-info__icon {
+.message__icon {
   flex: 0 0 auto;
   font-size: 1.5em;
   line-height: 1;
-  opacity: 0.7;
-  padding-right: 0.5em;
+  opacity: .7;
+  padding-right: .5em;
 }
 
-.alert--reverse {
+.message--reverse {
   background: none;
-  border: solid 1px #fff;
-  color: #fff;
+  border: solid 1px $color-white;
+  color: $color-white;
 }

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -23,10 +23,10 @@ $hero-color: $color-red;
 @import 'atoms/table';
 
 // Molecules
-@import 'molecules/alert';
 @import 'molecules/button-page-separator';
 @import 'molecules/card';
 @import 'molecules/list-group';
+@import 'molecules/message';
 @import 'molecules/panel';
 @import 'molecules/searchbar';
 @import 'molecules/slab';

--- a/brigade/templates/brigade_list.html
+++ b/brigade/templates/brigade_list.html
@@ -14,11 +14,11 @@ Explore the {{ brigades_total }} official Code for America brigades across the U
 <div class="slab slab--compact">
   <div class="grid-box">
     <div class="width-two-thirds">
-      <div class="alert-info">
-        <div class="alert-info__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fas fa-star"></i>
         </div>
-        <div class="alert-info__content">
+        <div class="message__content">
           No brigade near you? <strong>Start a new brigade!</strong><br>
           <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
         </div>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -18,11 +18,11 @@
 <section class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-half">
-      <div class="alert-info">
-        <div class="alert-info__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fas fa-info-circle"></i>
         </div>
-        <div class="alert-info__content">
+        <div class="message__content">
           <strong>Looking for a brigade event?</strong> <a href="/">Use the map</a> to find your local brigade.
         </div>
       </div>
@@ -74,11 +74,11 @@
         <li>We host events like workshops, forums and meetings, to share knowledge, experiences and lessons learned.</li>
         <li>All brigade members are encouraged to attend these events. To participate, check out the attached calendar.</li>
       </ul>
-      <div class="alert-info">
-        <div class="alert-info__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fas fa-question-circle"></i>
         </div>
-        <div class="alert-info__content">
+        <div class="message__content">
           <strong>Have a meeting or workshop to add to the calendar?</strong> <br>Let us know at <a href="mailto:brigade-info@codeforamerica.org">brigade-info@codeforamerica.org</a>
         </div>
       </div>

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -15,11 +15,11 @@ We're a national alliance of community organizers, developers, and designers tha
 <section id="overview" class="slab">
   <div class="grid-box">
     <div class="width-seven-twelfths">
-      <div class="alert-info">
-        <div class="alert-info__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fas fa-star"></i>
         </div>
-        <div class="alert-info__content">
+        <div class="message__content">
           No brigade near you? <strong>Start a new brigade!</strong><br>
           <a href="https://cfa.typeform.com/to/uxPQH6" target="_blank">Tell us about yourself and we'll help you get started.</a>
         </div>

--- a/brigade/templates/resources_videos.html
+++ b/brigade/templates/resources_videos.html
@@ -11,11 +11,11 @@
 <section class="slab slab--compact">
   <div class="grid-box">
     <div class="width-two-thirds">
-      <div class="alert-info">
-        <div class="alert-info__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fas fa-info-circle"></i>
         </div>
-        <div class="alert-info__content">
+        <div class="message__content">
           Check out <a href="https://www.youtube.com/user/CodeforAmerica/videos" target="_blank">Code for America's YouTube</a> for more videos.
         </div>
       </div>

--- a/brigade/templates/styleguide.html
+++ b/brigade/templates/styleguide.html
@@ -29,4 +29,26 @@
   </div>
 </section>
 
+<section class="slab">
+  <div class="grid-box">
+    <h2>Messages</h2>
+    <h3>Simple message</h3>
+    <div class="message">
+      <div class="message__content">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </div>
+    </div>
+    <h3>Message with an icon</h3>
+    <div class="message">
+      <div class="message__icon">
+        <i class="fas fa-star"></i>
+      </div>
+      <div class="message__content">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat.
+      </div>
+    </div>
+  </div>
+</section>
+
 {% endblock %}

--- a/brigade/templates/styleguide.html
+++ b/brigade/templates/styleguide.html
@@ -1,268 +1,32 @@
 {% extends "base.html" %}
+{% block title %}Style guide{% endblock %}
+{% block hero_title %}Brigade Website Styleguide{% endblock %}
 
 {% block content %}
 
-<section>
-  <div class="layout-semibreve">
-    <h1>Website Style Guide</h1>
-  </div>
-</section>
-
-<section>
-  <div class="layout-semibreve">
+<section class="slab">
+  <div class="grid-box">
     <h2>Typography</h2>
-
     <h1>Heading Level 1</h1>
     <h2>Heading Level 2</h2>
     <h3>Heading Level 3</h3>
     <h4>Heading Level 4</h4>
     <h5>Heading Level 5</h5>
   </div>
+</section>
 
-  <div class="layout-semibreve">
-    <h2>Cards</h2>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Card</h3>
-    <div class="layout-minim">
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Card with action</h3>
-    <div class="layout-minim">
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-        <div class="card__action">
-          <a href="#" class="button">Card Action Button</a>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Card with header</h3>
-    <div class="layout-minim">
-      <div class="card">
-        <div class="card__header">
-          Header text
-        </div>
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Card with footer</h3>
-    <div class="layout-minim">
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-        <div class="card__footer">
-          Footer text
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Card with icon</h3>
-    <div class="layout-minim">
-      <div class="card">
-        <div class="card__icon">
-          <i class="fas fa-laptop"></i>
-        </div>
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
-    <h3>Variant: card--horizontal</h3>
-    
-    <div class="layout-breve">
-      <div class="card card--horizontal">
-        <div class="card__header">
-          Header text
-        </div>
-        <div class="card__body">
-          <div class="card__aside">
-            <div class="card__icon">
-              <i class="fas fa-laptop"></i>
-            </div>
-          </div>
-          <div class="card__content">
-            <h2 class="card__title">Card title</h2>
-            <p>
-              The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-            </p>
-            <div class="card__action">
-              <a href="#" class="button">Card action</a>
-            </div>
-          </div>
-        </div>
-        <div class="card__footer">
-          Footer text
-        </div>
-      </div>
-    </div>
-
-    <div class="layout-breve">
-      <div class="card card--horizontal">
-        <div class="card__header">
-          Header text
-        </div>
-        <div class="card__body">
-          <div class="card__content">
-            <h2 class="card__title">Card title</h2>
-            <p>
-              The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-            </p>
-            <div class="card__action">
-              <a href="#" class="button">Card action</a>
-            </div>
-          </div>
-          <div class="card__aside">
-            <img src="{{ asset_url_for('images/8062-TS-0005.jpg') }}">
-          </div>
-        </div>
-        <div class="card__footer">
-          Footer text
-        </div>
-      </div>
-    </div>
-
-    <h3>Variant: card--multimedia</h3>
-    <p>Multimedia cards prominently feature a picture or video above the Card's title.</p>
-
-    <div class="layout-breve">
-      <div class="grid-box">
-        <div class="width-one-third">
-          <div class="card card--multimedia">
-            <iframe width="100%" height="240" src="https://www.youtube-nocookie.com/embed/qid8YLqayIM?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen=""></iframe>
-
-            <div class="card__body">
-              <h2 class="card--multimedia__title">
-                <a href="#">Media title</a>
-              </h2>
-              <p class="card--multimedia__metadata">May 14, 2018</p>
-              <p></p>
-
-            </div>
-            <div class="card__footer">
-              Footer text
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="layout-semibreve">
-    <h2>Card row</h2>
-  </div>
-
-  <div class="layout-semibreve">
-    <div class="card-row">
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-        <div class="card__action">
-          <a href="#" class="button">Card Action Button</a>
-        </div>
-      </div>
-    </div>
-    <div class="card-row">
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. 
-          </p>
-        </div>
-        <div class="card__action">
-          <a href="#" class="button">Card Action Button</a>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card__body">
-          <h2 class="card__title">Card title</h2>
-          <p>
-            The Code for America Brigade Network is a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities. We believe that government can work, for the people, by the people, in the 21<sup>st</sup> century, if we all help. 
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="layout-semibreve">
+<section class="slab">
+  <div class="grid-box">
     <h2>Buttons</h2>
-  </div>
-
-  <div class="layout-semibreve">
-    <p>Simple button<p>
+    <h3>Simple button<h3>
     <a class="button" href="#">Button Text Here!</a>
-
-    <p>Button Page Separator</p>
+    <h3>Button Page Separator</h3>
     <div class="button-page-separator">
       <div class="button-page-separator__button-container">
         <a class="button" href="#">Button Text Here?!</a>
       </div>
     </div>
   </div>
-
-
-
-</div>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
As we're updating the Brigade site to use the v4 styleguide, we realized that the site stylesheets and
the v4 styleguide both have an 'alert' component. @tdooner and I discussed it and realized that,
where we've been using the 'alert' component, it's been to provide information rather than to
'alert' the user of anything. Accordingly we agreed to rename the component to 'message'.

This commit also cleans up the SCSS for the message component slightly.