### PR TITLE
Update project showcase to work with v4 style guide

### DIFF
--- a/brigade/static/scss/core/_variables.scss
+++ b/brigade/static/scss/core/_variables.scss
@@ -7,16 +7,23 @@ $color-black: #000;
 $color-gray-dark: #5a5a5a;
 $color-white: #fff;
 
+$color-red: #cd1f42;
+$color-light-red: #d5405e;
+$color-dark-red: #bd1b3c;
+$color-blue: #399ed2;
+$color-light-blue: #57acd9;
+$color-dark-blue: #3591c0;
+
 $color-gray: #999;
 $color-gray-light: #e5e5e5;
 
-$color-primary: #cf1b41; /* CfA Red */
-$color-primary-light: #d5305e;
-$color-primary-dark: #bd1b3c;
+$color-primary: $color-red;
+$color-primary-light: $color-light-red;
+$color-primary-dark: $color-dark-red;
 
-$color-secondary: #399ed2; /* CfA Blue */
-$color-secondary-light: #57acd9;
-$color-secondary-dark: #3591c0;
+$color-secondary: $color-blue;
+$color-secondary-light: $color-light-blue;
+$color-secondary-dark: $color-dark-blue;
 
 $color-text-dark: $color-gray-dark;
 $color-text-light: $color-white;

--- a/brigade/static/scss/core/_variables.scss
+++ b/brigade/static/scss/core/_variables.scss
@@ -1,3 +1,5 @@
+@import '~@codeforamerica/style/_sass/core/_variables.scss';
+
 // 
 // Variables
 //
@@ -6,13 +8,6 @@
 $color-black: #000;
 $color-gray-dark: #5a5a5a;
 $color-white: #fff;
-
-$color-red: #cd1f42;
-$color-light-red: #d5405e;
-$color-dark-red: #bd1b3c;
-$color-blue: #399ed2;
-$color-light-blue: #57acd9;
-$color-dark-blue: #3591c0;
 
 $color-gray: #999;
 $color-gray-light: #e5e5e5;
@@ -30,6 +25,9 @@ $color-text-light: $color-white;
 
 $color-border-dark: $color-gray;
 $color-border-light: $color-gray-light;
+
+// Hero
+$hero-color: $color-red;
 
 // Breakpoints
 $mobile-up:     481px;

--- a/brigade/static/scss/molecules/_message.scss
+++ b/brigade/static/scss/molecules/_message.scss
@@ -6,15 +6,13 @@
 
 .message {
   background-color: $color-white;
-  border: solid $color-gray-light 1px;
+  border: 1px solid $color-gray-light;
   display: flex;
   flex-direction: row;
   font-size: .9em;
   line-height: 1.5em;
-  margin: {
-    bottom: 1rem;
-    top: 1rem;
-  }
+  margin-bottom: 1rem;
+  margin-top: 1rem;
   padding: .75em;
 
   a {

--- a/brigade/static/scss/molecules/_message.scss
+++ b/brigade/static/scss/molecules/_message.scss
@@ -5,14 +5,21 @@
 //
 
 .message {
-  background-color: $color-gray-light;
-  border: 0;
-  border-radius: 3px;
+  background-color: $color-white;
+  border: solid $color-gray-light 1px;
   display: flex;
   flex-direction: row;
-  font-size: 14px;
+  font-size: .9em;
   line-height: 1.5em;
-  padding: 1em;
+  margin: {
+    bottom: 1rem;
+    top: 1rem;
+  }
+  padding: .75em;
+
+  a {
+    color: $color-blue;
+  }
 }
 
 .message__content {
@@ -25,10 +32,4 @@
   line-height: 1;
   opacity: .7;
   padding-right: .5em;
-}
-
-.message--reverse {
-  background: none;
-  border: solid 1px $color-white;
-  color: $color-white;
 }

--- a/brigade/static/scss/style.scss
+++ b/brigade/static/scss/style.scss
@@ -1,15 +1,11 @@
 // Import the variables first, so they can be customized.
-@import '~@codeforamerica/style/_sass/core/_variables.scss';
-
-// Override style guide variables
-$hero-color: $color-red;
+@import 'core/variables';
 
 // Vendor
 @import '~bourbon-neat/app/assets/stylesheets/neat';
 @import '~@codeforamerica/style/_sass/main.scss';
 
 // Core
-@import 'core/variables';
 @import 'core/mixins';
 @import 'core/utilities';
 @import 'core/type';

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -56,6 +56,9 @@
                 {% block hero_description %}{% endblock %}
               </p>
             </div>
+            <div class="width-one-third shift-one-twelfth">
+              {% block hero_right %}{% endblock %}
+            </div>
           </div>
         </div>
       </section>

--- a/brigade/templates/project_showcase.html
+++ b/brigade/templates/project_showcase.html
@@ -3,38 +3,33 @@
 {% block description %}Explore some of the amazing work done by Brigades and find inspiration for your next project{% endblock %}
 {% block hero_title %}Project Showcase{% endblock %}
 {% block hero_description %}Explore some of the amazing work done by Brigades and find inspiration for your next project{% endblock %}
+{% block hero_right %}
+<div class="message">
+  <div class="message__icon">
+    <i class="fas fa-star"></i>
+  </div>
+  <div class="message__content">
+    <strong>Know an amazing Brigade project that should be on this page?</strong> 
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLScYO3puRDGeE0728WrlQtgr8d1AoryytTGYBcahVgfHHhCX4w/viewform?usp=sf_link" target="_blank">Let us know!</a>
+  </div>
+</div>
+{% endblock %}
 
 {% block page_id %}events{% endblock %}
 
 {% block content %}
 
-<header id="intro" class="page-header slab slab-dark-blue">
+<section id="overview" class="slab">
   <div class="grid-box">
     <div class="width-seven-twelfths">
-      <div class="alert alert--reverse">
-        <div class="alert__icon">
-          <i class="fas fa-star"></i>
-        </div>
-        <div class="alert__content">
-          <strong>Know an amazing Brigade project that should be on this page?</strong><br>
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLScYO3puRDGeE0728WrlQtgr8d1AoryytTGYBcahVgfHHhCX4w/viewform?usp=sf_link" target="_blank">Let us know!</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</header>
-
-<section id="overview" class="slab slab--compact slab-gray">
-  <div class="grid-box">
-    <div class="width-two-thirds">
-      <p>
+      <p class="lead-in-text">
         Showcase projects <strong>serve the public good</strong>, have clear goals that are <strong>aligned with the values of the Network</strong>, and are <strong>redeployable</strong>, with clean code and good documentation.
       </p>
-      <div class="alert">
-        <div class="alert__icon">
+      <div class="message">
+        <div class="message__icon">
           <i class="fab fa-github"></i>
         </div>
-        <div class="alert__content">
+        <div class="message__content">
           <strong>Looking for the Civic Tech Github Project Search?</strong>
           <a href="{{url_for('brigade.projects')}}">Find it here!</a>
         </div>
@@ -43,7 +38,7 @@
   </div>
 </section>
 
-<nav class="slab slab--compact">
+<nav class="slab gray-bg-slab slab--compact">
   <div class="grid-box">
     <h4>Explore by category:</h4>
     <a href="#safety-and-justice" class="button-s">Safety and Justice</a>
@@ -54,9 +49,9 @@
   </div>
 </nav>
 
-<section class="slab slab-gray border-bottom border-bottom">
-  <div class="grid-box" id="safety-and-justice">
-    <div class="width-two-thirds">
+<section class="slab" id="safety-and-justice">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
       <h2>Safety and Justice</h2>
       <div class="card">
         <div class="card__body">
@@ -66,13 +61,13 @@
             <div class="list-group__list-item">
               <strong>CourtBot</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Tulsa') }}">Code for Tulsa</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/codefortulsa/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://github.com/codefortulsa/courtbot" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
               </div>
             </div>
             <div class="list-group__list-item">
               <strong>CourtBot</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Atlanta') }}">Code for Atlanta</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/codeforatlanta/courtbot" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://github.com/codeforatlanta/courtbot" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
               </div>
             </div>
           </div>
@@ -86,7 +81,7 @@
             <div class="list-group__list-item">
               <strong>Buncombe County ReEntry Resources</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Greensboro') }}">Code for Greensboro</a></span>
               <div class="list-item__actions">
-                <a href="http://www.buncombereentryhub.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="http://www.buncombereentryhub.org/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
@@ -94,10 +89,12 @@
       </div>
     </div>
   </div>
-  <div class="grid-box"><hr></div>
-  <div class="grid-box" id="housing">
-    <h2>Housing</h2>
-    <div class="width-two-thirds">
+</section>
+
+<section class="slab border-top-slab" id="housing">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2>Housing</h2>
       <div class="card">
         <div class="card__body">
           <h3 class="card__title">Housing Insights</h3>
@@ -106,8 +103,8 @@
             <div class="list-group__list-item">
               <strong>Housing Insights</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-DC') }}">Code for DC</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/codefordc/housing-insights" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="http://housinginsights.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/codefordc/housing-insights" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="http://housinginsights.org/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
@@ -121,20 +118,20 @@
             <div class="list-group__list-item">
               <strong>Renter's Rights Guide</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-San-Jose') }}">Code for San Jose</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/codeforsanjose/renters-rights" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://rentersrightsguide.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/codeforsanjose/renters-rights" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://rentersrightsguide.org/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="width-one-third">
-      <div class="alert">
-        <div class="alert__icon">
+    <div class="width-one-third shift-one-twelfth">
+      <div class="message message--inverted">
+        <div class="message__icon">
           <i class="fab fa-youtube"></i>
         </div>
-        <div class="alert__content">
+        <div class="message__content">
           <strong>Want to learn more about housing projects in the Network?</strong><br>
           <a href="https://www.youtube.com/watch?v=xUL0EcGFCCY">Watch the Housing Workshop video!</a>
         </div>
@@ -142,10 +139,12 @@
       <iframe width="100%" height="200" src="https://www.youtube.com/embed/xUL0EcGFCCY" frameborder="0" allow="encrypted-media" allowfullscreen></iframe>
     </div>
   </div>
-  <div class="grid-box"><hr></div>
-  <div class="grid-box" id="food-security">
-    <h2>Food Security</h2>
-    <div class="width-two-thirds">
+</section>
+
+<section class="slab border-top-slab" id="food-security">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2>Food Security</h2>
       <div class="card">
         <div class="card__body">
           <h3 class="card__title">Food for Thought (Summer Meals)</h3>
@@ -154,8 +153,8 @@
             <div class="list-group__list-item">
               <strong>Food for Thought</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Tulsa') }}">Code for Tulsa</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/codefortulsa/food4thought" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://summer-meals.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/codefortulsa/food4thought" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://summer-meals.herokuapp.com/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
@@ -169,8 +168,8 @@
             <div class="list-group__list-item">
               <strong>Food Oasis LA</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Hack-for-LA') }}">Hack for LA</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/foodoasisla" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://foodoasis.la" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/foodoasisla" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://foodoasis.la" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
@@ -184,30 +183,32 @@
             <div class="list-group__list-item">
               <strong>NearGreen</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Philly') }}">Code for Philly</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/CodeForPhilly/neargreen" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://codeforphilly.github.io/neargreen/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/CodeForPhilly/neargreen" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://codeforphilly.github.io/neargreen/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="width-one-third">
-      <div class="alert">
-        <div class="alert__icon">
+    <div class="width-one-third shift-one-twelfth">
+      <div class="message">
+        <div class="message__icon">
           <i class="fab fa-youtube"></i>
         </div>
-        <div class="alert__content">
+        <div class="message__content">
           <strong>Want to learn more about food security projects in the Network?</strong><br>
-          <a href="https://www.youtube.com/watch?v=jvVZHmMmq9I">Watch the Brigade Food Security Workshop video!</a>
+          <a href="https://www.youtube.com/watch?v=jvVZHmMmq9I">Watch the Food Security Workshop video!</a>
         </div>
       </div>
       <iframe width="100%" height="250" src="https://www.youtube.com/embed/jvVZHmMmq9I" frameborder="0" allow="encrypted-media" allowfullscreen></iframe>
     </div>
   </div>
-  <div class="grid-box"><hr></div>
-  <div class="grid-box" id="transportation">
-    <div class="width-two-thirds">
+</section>
+
+<section class="slab border-top-slab" id="transportation">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
       <h2>Transportation</h2>
       <div class="card">
         <div class="card__body">
@@ -217,8 +218,8 @@
             <div class="list-group__list-item">
               <strong>CyclePhilly</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Philly') }}">Code for Philly</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/CodeForPhilly/cyclephilly" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="http://www.cyclephilly.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/CodeForPhilly/cyclephilly" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="http://www.cyclephilly.org/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>
@@ -226,9 +227,11 @@
       </div>
     </div>
   </div>
-  <div class="grid-box"><hr></div>
-  <div class="grid-box" id="public-works">
-    <div class="width-two-thirds">
+</section>
+
+<section class="slab border-top-slab" id="public-works">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
       <h2>Public Works</h2>
       <div class="card">
         <div class="card__body">
@@ -238,15 +241,15 @@
             <div class="list-group__list-item">
               <strong>Adopt a Drain SF</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-San-Francisco') }}">Code for San Francisco</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/sfbrigade/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://adoptadrain.sfwater.org/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/sfbrigade/adopt-a-drain" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://adoptadrain.sfwater.org/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
             <div class="list-group__list-item">
               <strong>Norfolk Drains</strong> <span class="no-wrap">by <a href="{{ url_for('brigade.brigade', brigadeid='Code-for-Hampton-Roads') }}">Code for Hampton Roads</a></span>
               <div class="list-item__actions">
-                <a href="https://github.com/Code4HR/adopt-a-drain" class="button" target="_blank">View code <i class="fab fa-github"></i></a>
-                <a href="https://norfolkdrains.herokuapp.com/" class="button" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
+                <a href="https://github.com/Code4HR/adopt-a-drain" class="button button-outline" target="_blank">View code <i class="fab fa-github"></i></a>
+                <a href="https://norfolkdrains.herokuapp.com/" class="button button-primary" target="_blank">Visit project <i class="fas fa-external-link-alt"></i></a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR updates the the layout of the Project Showcase page to work with the v4 style guide. It also updates the `message` component to be more subtle and more consistent with the look of the main website and the v4 style guide. 

The update Project Showcase page looks like this:
![image](https://user-images.githubusercontent.com/8628090/43735212-f42b2334-996e-11e8-987a-c405d4a57f23.png)