### PR TITLE
Update "Brigade Congress" on brigade website

### DIFF
--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -23,7 +23,7 @@
     <div class="js-container">
       <div class="global-header global-header--above">
         <a href="https://www.codeforamerica.org/brigade-congress" target="_blank">
-          Attend a unique knowledge sharing and networking event for Brigade leaders.
+          Attend a unique knowledge sharing and training event for Brigade leaders.
           <span class="global-header__above-underline">
             Get your ticket to Brigade Congress today.
           </span>

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -21,6 +21,15 @@
   <body id="{% block page_id %}{% endblock %}">
 
     <div class="js-container">
+      <div class="global-header global-header--above">
+        <a href="https://www.codeforamerica.org/brigade-congress" target="_blank">
+          Attend a unique knowledge sharing and networking event for Brigade leaders.
+          <span class="global-header__above-underline">
+            Get your ticket to Brigade Congress today.
+          </span>
+        </a>
+      </div>
+
 
       <nav class="nav-global-primary">
       </nav>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -55,7 +55,10 @@
             <a href="https://www.codeforamerica.org/brigade-congress" target="_blank"><strong>Brigade Congress</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
           </h3>
           <p>
-            Brigade Congress is the primary in-person meeting centered on the Code for America Network–Brigade leaders, government and community partners, and civic tech professionals. Join us in Charlotte, North Carolina for this unique knowledge-sharing and training event.
+            Brigade Congress is the primary in-person meeting centered on the Code for America Network, bringing together Brigade leaders, government and community partners, and civic tech professionals from across the country.
+          </p>
+          <p>
+            Join us in Charlotte, North Carolina for this unique knowledge-sharing and training event.
           </p>
         </li>
         <li>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -44,16 +44,18 @@
         <li>
           <h3>
             <small>August 11, 2018</small> <br>
-            <a href="http://nationaldayofcivichacking.org" target="_blank"><strong>National Day of Civic Hacking</strong> <i class="fas fa-external-link-alt fa-xs"></i></a></a>
+            <a href="http://nationaldayofcivichacking.org" target="_blank"><strong>National Day of Civic Hacking</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
           </h3>
           <p>
             This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the 21<sup>st</sup> century if we all build it together.
           </p>
         </li>
         <li>
-          <h3><small>October 19–21, 2018</small> <br><strong>Brigade Congress</strong></h3>
+          <h3><small>October 19–21, 2018</small> <br>
+            <a href="https://www.codeforamerica.org/brigade-congress" target="_blank"><strong>Brigade Congress</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
+          </h3>
           <p>
-            Brigade Congress is an annual unconference where brigade participants share stories on what has worked, what hasn't, and how we can apply those lessons to future wins. (More details coming soon!)
+            Brigade Congress is the primary in-person meeting centered on the Code for America Network–Brigade leaders, government and community partners, and civic tech professionals. Join us in Charlotte, North Carolina for this unique knowledge-sharing and training event.
           </p>
         </li>
         <li>


### PR DESCRIPTION
1. Add a sitewide header for it
2. Update its entry on the events page to link to the official site, and its description to match our existing marketing copy.