### PR TITLE
Update Home and About pages

### DIFF
--- a/brigade/static/scss/atoms/_button.scss
+++ b/brigade/static/scss/atoms/_button.scss
@@ -7,3 +7,11 @@
 .button {
   box-sizing: border-box !important; // TODO: Get rid of !important (the old CfA stylesheet we're using right now overides the button box-sizing)
 }
+
+// Override the font name used in button icons
+// TODO: Upgrade the style guide to Font Awesome 5.
+.button-download::after,
+.button-linkout::after {
+  font-weight: 700 !important;
+  font-family: "Font Awesome 5 Free" !important;
+}

--- a/brigade/static/scss/atoms/_list.scss
+++ b/brigade/static/scss/atoms/_list.scss
@@ -6,16 +6,18 @@
 
 .list--inline {
   list-style-type: none;
+  padding: 0;
+
   li {
-    background-image: none;        
-    display: inline;
+    display: inline-block;
+    margin: .625rem 3rem .625rem 0;
   }
 }
 
 .list--no-bullets {
   list-style-type: none;
+
   li {
-    background-image: none;
     padding-left: 0;
   }
 }
@@ -31,6 +33,5 @@
 .fa-ul {
   li {
     list-style-type: none;
-    background-image: none;  
   }
 }

--- a/brigade/templates/about.html
+++ b/brigade/templates/about.html
@@ -30,7 +30,7 @@ Code for America Brigades are volunteer groups that collaborate with local gover
     <div class="width-one-half">
     <h2>Code of Conduct</h2>
     <p>Code for America has a Code of Conduct that applies to our activities, events, and digital forums. We do not tolerate discrimiation or harrassment of any kind.</p>
-    <a href="https://github.com/codeforamerica/codeofconduct" class="button button-outline" title="Code of Conduct on Github">Check out our full Code of Conduct</a>
+    <a href="https://github.com/codeforamerica/codeofconduct" class="button button-outline button-linkout" title="Code of Conduct on Github" target="_blank">Check out our full Code of Conduct</a>
   </div>
   </div>
 </section>

--- a/brigade/templates/about.html
+++ b/brigade/templates/about.html
@@ -36,9 +36,10 @@ Code for America Brigades are volunteer groups that collaborate with local gover
 </section>
 
 <section class="slab" id="sponsors">
-  <div class="panel">
-    <div class="panel__body layout-centered">
-      <h4>Funders</h4>
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2>Funders</h2>
+
       <ul class="list list--inline">
         <li><a href="https://www.rallydev.com/about/rally-for-impact" target="_blank"><img src="{{ asset_url_for('images/CAlogo.png') }}" height="60px"></a></li>
         <li><a href="https://www.esri.com/" target="_blank"><img src="{{ asset_url_for('images/logo_esri.png') }}" height="60px"></a></li>

--- a/brigade/templates/about.html
+++ b/brigade/templates/about.html
@@ -30,7 +30,7 @@ Code for America Brigades are volunteer groups that collaborate with local gover
     <div class="width-one-half">
     <h2>Code of Conduct</h2>
     <p>Code for America has a Code of Conduct that applies to our activities, events, and digital forums. We do not tolerate discrimiation or harrassment of any kind.</p>
-    <a href="https://github.com/codeforamerica/codeofconduct" class="button button-bold" title="Code of Conduct on Github">Check out our full Code of Conduct</a>
+    <a href="https://github.com/codeforamerica/codeofconduct" class="button button-outline" title="Code of Conduct on Github">Check out our full Code of Conduct</a>
   </div>
   </div>
 </section>
@@ -46,7 +46,7 @@ Code for America Brigades are volunteer groups that collaborate with local gover
         <li><a href="https://knightfoundation.org/" target="_blank"><img src="{{ asset_url_for('images/logo_knightfoundation.png') }}" height="60px"></a></li>
       </ul>
     </div>
-  </div>    
+  </div>
 </section>
 
 {% endblock %}

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -12,7 +12,7 @@ We're a national alliance of community organizers, developers, and designers tha
 
 {% block content %}
 
-<section id="overview" class="slab">
+<section id="overview" class="slab slab--compact">
   <div class="grid-box">
     <div class="width-seven-twelfths">
       <div class="message">
@@ -28,7 +28,7 @@ We're a national alliance of community organizers, developers, and designers tha
   </div>
 </section>
 
-<section class="slab">
+<section class="slab slab--compact">
   <div class="grid-box">
     <div class="width-one-whole">
       <div id="map"></div>

--- a/brigade/templates/index.html
+++ b/brigade/templates/index.html
@@ -42,14 +42,15 @@ We're a national alliance of community organizers, developers, and designers tha
 <section id="sponsors" class="slab">
   <div class="grid-box">
     <div class="width-one-whole">
-      <h4>Funders</h4>
+      <h3>Funders</h3>
+
       <ul class="list list--inline">
         <li><a href="https://www.rallydev.com/about/rally-for-impact" target="_blank"><img src="{{ asset_url_for('images/CAlogo.png') }}" height="60"></a></li>
         <li><a href="https://www.esri.com/" target="_blank"><img src="{{ asset_url_for('images/logo_esri.png') }}" height="60"></a></li>
         <li><a href="https://knightfoundation.org/" target="_blank"><img src="{{ asset_url_for('images/logo_knightfoundation.png') }}" height="60"></a></li>
       </ul>
     </div>
-  </div>    
+  </div>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
Minor tweaks:
- condense homepage a bit
- expand gaps between sponsor logos
- paper-over Font Awesome version discrepancy (v5 here, vs v4 in style guide) for button styles
- update CoC button on About page to use the new external link button