### PR TITLE
Handle statewide collaborations when pulling from cfapi

### DIFF
--- a/cfapi/__init__.py
+++ b/cfapi/__init__.py
@@ -92,8 +92,9 @@ def get_brigades(official_brigades_only=False):
 def get_official_brigades_by_state():
     brigades = get_brigades(official_brigades_only=True)
     states = {}
-    # Find all two-letter state abbreviations in the brigade's city, and add brigade to those states
     for brigade in brigades:
+        # Find all two-letter state abbreviations in the brigade's city (e.g.
+        # "Kansas City, MO & KS"), and add the brigade to those states
         brigade_states = re.findall(
             r'\b([A-Z]{2})\b', brigade['properties']['city'])
         for state in brigade_states:
@@ -101,6 +102,14 @@ def get_official_brigades_by_state():
             if state_fullname not in states:
                 states[state_fullname] = []
             states[state_fullname].append(brigade['properties'])
+
+        # Handle statewide collaborations like "North Carolina" or "California"
+        if brigade['properties']['city'] in STATE_NAMES.values():
+            state_fullname = brigade['properties']['city']
+            if state_fullname not in states:
+                states[state_fullname] = []
+            states[state_fullname].append(brigade['properties'])
+
     for brigades in states.values():
         brigades.sort(key=lambda b: b['name'])
     return states

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -53,6 +53,16 @@ class BrigadeTests(unittest.TestCase):
                             "last_updated": 1510874211,
                             "city": "Atlantis, GA"
                         } 
+                    },
+                    {
+                        "id": "Code-for-Georgians",
+                        "properties" : {
+                            "id": "Code-for-Georgians",
+                            "name": "Code for Georgians",
+                            "tags": ["Brigade", "Official", "Code for America"],
+                            "last_updated": 1510874211,
+                            "city": "Georgia"
+                        }
                     }]
                 }''') # noqa
         if url.geturl() == cfapi.BASE_URL + "/projects/1":
@@ -248,6 +258,7 @@ class BrigadeTests(unittest.TestCase):
             self.assertEqual(len(brigades), 2)
             self.assertIn("Georgia", brigades)
             self.assertEquals(brigades["Georgia"][0]['id'], "Code-for-Atlantis")
+            self.assertEquals(brigades["Georgia"][1]['id'], "Code-for-Georgians")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These collaborations have city fields that are actually states. We can
lump the brigade into that state by checking for this case.

For "Open NC Collaborative" they were already on the map, but missing
from the list because their state wasn't in the list of states.