### PR TITLE
Reduce subhero padding-bottom and improve map interaction

### DIFF
--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -22,8 +22,19 @@ window.Brigade.initializeMap = function(geoJSON) {
   geocoderControl.setPosition('topright');
   geocoderControl.addTo(map);
 
-  map.addEventListener('ready', function() {
+  /*
+   * Disable scrolling until the user moves the mouse over the map for the
+   * first time. This should hopefully result in users scrolling past the map
+   * when using a scroll wheel if they don't move the mouse.
+   */
+  map.scrollWheelZoom.disable();
+  map.addEventListener('mousemove', function() {
+    if (!map.scrollWheelZoom.enabled()) {
+      map.scrollWheelZoom.enable();
+    }
+  });
 
+  map.addEventListener('ready', function() {
     $('.leaflet-control-mapbox-geocoder-form input').attr("placeholder","Search map");
 
     // After selecting a geocoder result, replace the search text with the place name and hide the geocoder results

--- a/brigade/static/js/application.js
+++ b/brigade/static/js/application.js
@@ -41,7 +41,6 @@ window.Brigade.initializeMap = function(geoJSON) {
     $('a.leaflet-control-mapbox-geocoder-toggle').on('click', function(event){
       event.preventDefault();
     });
-
   });
 
   map.zoomControl.setPosition('topright');

--- a/brigade/static/scss/organisms/_subhero.scss
+++ b/brigade/static/scss/organisms/_subhero.scss
@@ -1,6 +1,5 @@
 @import '../core/variables';
 
 .subhero {
-  padding-left: $site-margins;
-  padding-right: $site-margins;
+  padding: 4rem $site-margins 0;
 }

--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -66,15 +66,13 @@
       {% endif %}
 
       <section class="subhero">
-        <div class="slab">
-          <div class="grid-box">
-            <div class="width-seven-twelfths">
-              <h1>{% block subhero_title %}{% endblock %}</h1>
-              {% block subhero_description %}{% endblock %}
-            </div>
-            <div class="width-one-third shift-one-twelfth">
-              {% block hero_right %}{% endblock %}
-            </div>
+        <div class="grid-box">
+          <div class="width-seven-twelfths">
+            <h1>{% block subhero_title %}{% endblock %}</h1>
+            {% block subhero_description %}{% endblock %}
+          </div>
+          <div class="width-one-third shift-one-twelfth">
+            {% block hero_right %}{% endblock %}
           </div>
         </div>
       </section>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -4,15 +4,6 @@
 {% block subhero_title %}Events{% endblock %}
 {% block subhero_description %}
 <p class="lead-in-text">Events happening across the Code for America Brigade Network</p>
-
-<div class="message">
-  <div class="message__icon">
-    <i class="fas fa-info-circle"></i>
-  </div>
-  <div class="message__content">
-    <strong>Looking for a brigade event?</strong> <a href="/">Use the map</a> to find your local brigade.
-  </div>
-</div>
 {% endblock %}
 {% block page_id %}events{% endblock %}
 {% block in_page_nav %}
@@ -21,6 +12,16 @@
   <a href="#key-dates" class="in-page-nav__link">Key Dates</a>
   <a href="#workshops-and-meetings" class="in-page-nav__link">Workshops and Meetings</a>
 </nav>
+{% endblock %}
+{% block hero_right %}
+<div class="message">
+  <div class="message__icon">
+    <i class="fas fa-info-circle"></i>
+  </div>
+  <div class="message__content">
+    <strong>Looking for a brigade event?</strong> <a href="/">Use the map</a> to find your local brigade.
+  </div>
+</div>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
The feedback from the team was around two points:
1. the site felt a bit too spacious (too much padding)
2. the map interaction on the homepage was tripped up by scroll wheels

To the first point, by making the subhero not a "slab" anymore removes its padding-bottom and looks pretty good.

The map interaction was tricky, but by disabling scroll zooming until a `mousemove` event is triggered, I think will work pretty well.