### PR TITLE
Add Code of Conduct page to Brigade Website

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,9 +4,6 @@
   "scripts": {
   },
   "env": {
-    "ACCESS_TOKEN": {
-      "required": true
-    },
     "ERROR_PAGE_URL": {
       "required": true
     },

--- a/brigade/templates/about.html
+++ b/brigade/templates/about.html
@@ -30,7 +30,7 @@ Code for America Brigades are volunteer groups that collaborate with local gover
     <div class="width-one-half">
     <h2>Code of Conduct</h2>
     <p>Code for America has a Code of Conduct that applies to our activities, events, and digital forums. We do not tolerate discrimiation or harrassment of any kind.</p>
-    <a href="https://github.com/codeforamerica/codeofconduct" class="button button-outline button-linkout" title="Code of Conduct on Github" target="_blank">Check out our full Code of Conduct</a>
+    <a href="{{ url_for('brigade.code_of_conduct') }}" class="button button-outline">Check out our full Code of Conduct</a>
   </div>
   </div>
 </section>

--- a/brigade/templates/code_of_conduct.html
+++ b/brigade/templates/code_of_conduct.html
@@ -4,7 +4,9 @@ Code of Conduct
 {% endblock %}
 {% block subhero_description %}
 <p class="lead-in-text">
-Code for America believes unequivocally that anyone attending a Code for America event should be in a safe environment free from harassment. We expect attendees at every Code for America or Code for America Brigade event to adhere to a Code of Conduct.
+Code for America believes that anyone attending a Code for America event or participating in our online community should feel safe and be free from harassment.
+</p>
+<p class="lead-in-text">As such, we expect all attendees to adhere to the Code of Conduct at every Code for America or Code for America Brigade event.
 </p>
 {% endblock %}
 {% block in_page_nav %}
@@ -22,7 +24,7 @@ Code for America believes unequivocally that anyone attending a Code for America
   <div class="grid-box">
     <div class="width-seven-twelfths">
       <h2 id="code-of-conduct">Code for America's Code of Conduct</h2>
-      
+
       <p>The Code for America community expects that Code for America network activities, events, and digital forums:</p>
 
       <ol>

--- a/brigade/templates/code_of_conduct.html
+++ b/brigade/templates/code_of_conduct.html
@@ -1,0 +1,131 @@
+{% extends "base.html" %}
+{% block subhero_title %}
+Code of Conduct
+{% endblock %}
+{% block subhero_description %}
+<p class="lead-in-text">
+Code for America believes unequivocally that anyone attending a Code for America event should be in a safe environment free from harassment. We expect attendees at every Code for America or Code for America Brigade event to adhere to a Code of Conduct.
+</p>
+{% endblock %}
+{% block in_page_nav %}
+<nav>
+  <strong>On this page:</strong>
+  <a href="#code-of-conduct" class="in-page-nav__link">Code of Conduct</a>
+  <a href="#anti-harassment" class="in-page-nav__link">Anti-Harassment Policy</a>
+  <a href="#reporting-template" class="in-page-nav__link">Reporting Template</a>
+  <a href="#slack" class="in-page-nav__link">Slack Policy</a>
+</nav>
+{% endblock %}
+
+{% block content %}
+<section class="slab">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2 id="code-of-conduct">Code for America's Code of Conduct</h2>
+      
+      <p>The Code for America community expects that Code for America network activities, events, and digital forums:</p>
+
+      <ol>
+        <li>Are a safe and respectful environment for all participants.</li>
+        <li>Are a place where people are free to fully express their identities.</li>
+        <li>Presume the value of others. Everyone’s ideas, skills, and contributions have value.</li>
+        <li>Don’t assume everyone has the same context, and encourage questions.</li>
+        <li>Find a way for people to be productive with their skills (technical and not) and energy. Use language such as “yes/and”, not “no/but.”</li>
+        <li>Encourage members and participants to listen as much as they speak.</li>
+        <li>Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.</li>
+        <li>Prioritize access for and input from those who are traditionally excluded from the civic process.</li>
+        <li>Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups.</li>
+        <li>Actively involve community groups and those with subject matter expertise in the decision-making process.</li>
+        <li>Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.</li>
+        <li>Provide an environment where people are free from discrimination or harassment.</li>
+      </ol>
+
+      <p>Code for America reserves the right to ask anyone in violation of these policies not to participate in Code for America network activities, events, and digital forums.</p>
+
+      <p>&nbsp;</p>
+
+      <p>
+        <em>
+          This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
+        </em>
+      </p>
+    </div>
+
+    <div class="width-one-third shift-one-twelfth">
+      <div class="message">
+        <div class="message__icon">
+          <i class="fas fa-info-circle"></i>
+        </div>
+        <div class="message__content">
+          <strong>Looking to adopt the Code of Conduct for your Brigade?</strong>
+          <a href="https://docs.google.com/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit" target="_blank">Consult this how-to guide</a>.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slab border-top-slab">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2 id="anti-harassment">Code for America's Anti-Harassment Policy</h2>
+
+      <p><em>All Code for America Network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.</em></p>
+      <p><em>In addition to governing our own events by this policy, Code for America will only lend our brand and support groups that offer an anti-harassment policy to their attendees.</em></p>
+
+      <p>Code for America is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may expelled from Code for America network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.</p>
+      <p>Harassment includes but is not limited to:</p>
+      <ul>
+        <li>offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion</li>
+        <li>sexual images in public spaces</li>
+        <li>deliberate intimidation</li>
+        <li>stalking</li>
+        <li>following</li>
+        <li>harassing photography or recording</li>
+        <li>sustained disruption of talks or other events</li>
+        <li>inappropriate physical contact</li>
+        <li>unwelcome sexual attention</li>
+        <li>unwarranted exclusion</li>
+        <li>patronizing language or action.</li>
+      </ul>
+      </p>
+      <p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for America network activities, events, and digital forums.</p>
+      <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff or forum administrator immediately. You can contact them at <a href="mailto:safespace@codeforamerica.org">safespace@codeforamerica.org</a>. Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.</p>
+      <p>If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or remove yourself from the situation.</p>
+      <p>When contacting Code for America about harassment, feel free to use <a href="#reporting-template">the email template below</a>. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.</p>
+      <p>We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.</p>
+
+      <p>&nbsp;</p>
+
+      <p>
+        <em>
+          This anti-harassment policy is based on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy" target="_blank">the example policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
+        </em>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="slab border-top-slab">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h3 id="reporting-template">Email Template for Reporting</h3>
+      <p>TO: safespace@codeforamerica.org</p>
+      <p>SUBJECT: Safe Space alert at [EVENT NAME]</p>
+      <p>I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT).</p>
+      <p>You can reach me at (CONTACT INFO). Thank you.</p>
+    </div>
+  </div>
+</section>
+
+<section class="slab border-top-slab">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h2 id="slack">Slack Policy</h2>
+      <p>Code for America enforces its Code of Conduct on Slack and all other forums as well.</p>
+      <a href="https://docs.google.com/document/d/1xYEfMV7IyKUOly1bOKpeWQCws-5M2kmE2nPc29v9IcI/edit#heading=h.l4wed8ft07kd" target="_blank" class="button button-outline button-linkout">View our Slack policy</a>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/brigade/templates/resources.html
+++ b/brigade/templates/resources.html
@@ -14,7 +14,7 @@
       <div class="span-four grid-item">
         <a href="https://docs.google.com/document/d/1G_v53fGyHqdZNmXkDxqhqkzT7q2TBZ9Xmh9JkWtFQ8Y/edit" class="card link-card" target="_blank" title="Playbook Google Doc view">
           <div class="card-image--icon">
-            <i class="fas fa-tasks"></i>
+            <i class="fas fa-book"></i>
           </div>
           <div class="card-content">
             <h4>Organizer’s Playbook</h4>
@@ -27,15 +27,28 @@
       </div>
 
       <div class="span-four grid-item">
-        <a href="https://docs.google.com/document/d/16CL9TdmWV0hDY6c85PwtzUcu1VjeSeiDFD2CbtLKf7s/edit?usp=sharing" class="card link-card" target="_blank" title="Handbook Google Doc view">
+        <a href="{{ url_for('.code_of_conduct') }}" class="card link-card">
           <div class="card-image--icon">
-            <i class="fas fa-book"></i>
+            <i class="fas fa-users"></i>
           </div>
           <div class="card-content">
-            <h4>Organizer’s Handbook</h4>
-            <p>The Handbook points to the resources that CfA offers Brigades and how to take advantage of them.</p>
-            <p>It includes: how to get set up on Meetup, how to use Expensify, and information about the National Advisory Council (NAC).</p>
-            <div class="card-link">View Handbook <i class="fas fa-xs fa-external-link-alt"></i></div>
+            <h4>Code of Conduct</h4>
+            <p>Lay the foundation to create a safe space at your Brigade event.</p>
+            <div class="card-link">Adapt our Code of Conduct</div>
+          </div>
+        </a>
+      </div>
+
+      <div class="span-four grid-item">
+        {# TODO: Replace this with the new Financial Guidance page #}
+        <a href="https://docs.google.com/document/d/1rlBlOBLzzUm3wr9asZ5OEnnC8EhvDnMSwUaMAh-J83E/edit" target="_blank" class="card link-card">
+          <div class="card-image--icon">
+            <i class="fas fa-dollar-sign"></i>
+          </div>
+          <div class="card-content">
+            <h4>Financial Guidance</h4>
+            <p>If you're looking to raise money, spend it, or sign a contract, look here for step-by-step instructions.</p>
+            <div class="card-link">View Financial Guidance</div>
           </div>
         </a>
       </div>

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -217,6 +217,10 @@ def redirect_brigade(brigadeid):
     return redirect(url_for('.brigade', brigadeid=brigadeid), code=301)
 
 
+@app.route('/code-of-conduct')
+def code_of_conduct():
+    return render_template("code_of_conduct.html")
+
 @app.route('/brigades/<brigadeid>/')
 def brigade(brigadeid):
     ''' Get this Brigade's info '''

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -217,7 +217,7 @@ def redirect_brigade(brigadeid):
     return redirect(url_for('.brigade', brigadeid=brigadeid), code=301)
 
 
-@app.route('/code-of-conduct')
+@app.route('/about/code-of-conduct')
 def code_of_conduct():
     return render_template("code_of_conduct.html")
 


### PR DESCRIPTION
We want to create a CoC page that is a bit more intuitive and visually
capable than a Github repo. Changes from Github will have to be
syndicated here manually.