### PR TITLE
Add "Other Links" section for Discourse & Fellowship

### DIFF
--- a/brigade/templates/resources.html
+++ b/brigade/templates/resources.html
@@ -99,7 +99,24 @@
   </div>
 </section>
 
-<div class="slab gray-bg-slab slab--compact">
+<div class="slab slab--compact">
+  <div class="grid-box">
+    <div class="width-seven-twelfths">
+      <h3>Other links</h3>
+      <p>You may also find these related links helpful:</p>
+      <ul>
+        <li><strong><a href="https://discourse.codeforamerica.org" target="_blank">Code for America Network Discourse</a></strong> – An online message board for Brigade members and captains to share knowledge.</li>
+        <li><strong><a href="https://www.codeforamerica.org/fellowship" target="_blank">Community Fellowship</a></strong> – The Community Fellowship program pairs local Brigade talent with government to improve services for vulnerable people they serve.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="slab slab--compact">
+  {# spacer #}
+</div>
+
+<div class="slab slab--compact gray-bg-slab">
   <div class="grid-box">
     <div class="width-one-third">
       <div class="message">


### PR DESCRIPTION
We wanted to link to these as well, though creating a full card for them
seems a bit odd since they are different than the other resources listed
already. I've broken them into a separate section of other links that
may be useful.

Although this approach doesn't scale for _many_ links, it'll work to get
a few more links on the page and improve the SEO of the Discourse.