### PR TITLE
Hide Brigade "Donate" links for some Brigades

### DIFF
--- a/brigade/templates/brigade.html
+++ b/brigade/templates/brigade.html
@@ -65,7 +65,9 @@
   {% if brigade.current_stories %}
   <a href="#stories" class="in-page-nav__link">Stories</a>
   {% endif %}
+  {% if brigade.can_donate_through_cfa %}
   <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page{% if brigade %}&brigade={{ brigade.name }}{% endif %}" class="in-page-nav__link" target="_blank"> Donate <i class="fas fa-xs fa-external-link-alt"></i></a>
+  {% endif %}
 </nav>
 {% endblock %}
 

--- a/brigade/views.py
+++ b/brigade/views.py
@@ -250,6 +250,11 @@ def brigade(brigadeid):
         if event_date == todays_date:
             brigade['current_events'][0]['is_today'] = True
 
+    ''' If Brigade is fiscally sponsored or a partner Brigade, it can't be donated '''
+    brigade['can_donate_through_cfa'] = \
+        not 'Code for America Fiscally Sponsored Brigade' in brigade['tags'] \
+        and not 'Code for America Partner Brigade' in brigade['tags']
+
     return render_template("brigade.html", brigade=brigade, brigadeid=brigadeid)
 
 


### PR DESCRIPTION
As of 2019, CfA will no longer accept donations for Fiscally Sponsored
or Partner Brigades. Let's make sure we don't lead users to the wrong
donate page.