### PR TITLE
Issue #588 - server error on 404 pages that are not under /brigades/ subfolder

### DIFF
--- a/brigade/templates/404.html
+++ b/brigade/templates/404.html
@@ -5,7 +5,7 @@
   <div class="grid-box">
     <h1>Error: Page Not Found</h1>
     <p>We weren't able to find that page.</p>
-    <a href="{{ url_for('.index') }}"> &larr; Return to Home</a>
+    <a href="{{ url_for('brigade.index') }}"> &larr; Return to Home</a>
   </div>
 </section>
 {% endblock %}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -155,6 +155,8 @@ class BrigadeTests(unittest.TestCase):
         with httmock.HTTMock(self.response_content):
             response = self.client.get("/brigades/404/")
             self.assertEqual(404, response.status_code)
+            response = self.client.get("/broken-link/")
+            self.assertEqual(404, response.status_code)
 
     def test_projects_searches(self):
         ''' Test the different project searches '''


### PR DESCRIPTION
Addresses Issue #588 where 500 errors are being sent on pages that apparently should be a 404.

The 500 was due to a broken URL reverse, that appears to have been residual from a move from /brigades/ to brigade.codeforamerica.org. The 404 page test was still passing because it referenced the 404 on the /brigades/ URL.

Link and test case have been updated.