### PR TITLE
Remove Bizspark/Azure from free software pages

### DIFF
--- a/brigade/templates/free_software.html
+++ b/brigade/templates/free_software.html
@@ -57,18 +57,6 @@ Code for America is excited to offer the software linked below to help with proj
     </div>
 
     <div class="span-four grid-item">
-      <a class="card link-card" href="{{ url_for(".free_software_show", software="bizspark") }}">
-        <div class="card-image-container">
-          <img src="{{ asset_url_for('images/software_bizspark.jpg') }}" width="200px" />
-        </div>
-        <div class="card-content">
-          <p>Microsoft's Bizspark program offers free Microsoft software and credits for their cloud platform, Azure.</p>
-          <span class="card-link">Learn more</span>
-        </div>
-      </a>
-    </div>
-
-    <div class="span-four grid-item">
       <a class="card link-card" href="{{ url_for(".free_software_show", software="twilio") }}">
         <div class="card-image-container">
           <img src="{{ asset_url_for('images/software_twilio.png') }}" width="200px" />

--- a/brigade/templates/free_software/bizspark.html
+++ b/brigade/templates/free_software/bizspark.html
@@ -5,6 +5,13 @@
 {% endblock %}
 
 {% block software %}
+<div class="message">
+  <div class="message__content">
+    <strong>Note: </strong>
+    As of February 2018, Microsoft no longer provides Bizspark access or Azure credits to Code for America Brigades.
+  </div>
+</div>
+
 <h2>Microsoft Bizspark / Azure</h2>
 <h3>What is Bizspark / Azure?</h3>
 <p>BizSpark is a program that Microsoft offers to small organizations which includes many common Microsoft products and free Azure credits for hosting.</p>


### PR DESCRIPTION
According to the last person who tried to claim this inkind:

"It seems that Microsoft has closed BizSpark last year and changed their
target audience:

> What happened to BizSpark and BizSpark Plus?
> As of February 2018, we are no longer accepting applications for the
> BizSpark or BizSpark Plus programs. We are accepting applications for
> the Microsoft for Startups program and any startup currently enrolled in
> BizSpark or BizSpark Plus will be able to access their benefits for the
> balance of the time outlined at the outset of their membership. If you
> were, or are, a member of BizSpark and you fit the guidelines for
> Microsoft for Startups’ new qualified offers, we invite you to apply.
> For additional questions and support resources, please feel free to
> contact us: BizSpark Plus Support / BizSpark Support"

Given that, let's remove this from the page.