### PR TITLE
Add redirect from "previous_names" to current name

### DIFF
--- a/brigade/views.py
+++ b/brigade/views.py
@@ -118,8 +118,11 @@ def projects(brigadeid=None):
 
     # is this an exisiting group
     if brigadeid:
-        if not cfapi.is_existing_organization(brigadeid):
+        brigade = cfapi.find_brigade(brigadeid)
+        if not brigade:
             return render_template('404.html'), 404
+        elif brigade["id"] != brigadeid:
+            return redirect(url_for("brigade.projects", brigadeid=brigade["id"]))
 
     # Get the params
     projects = []
@@ -173,8 +176,11 @@ def rsvps(brigadeid=None):
     ''' Show the Brigade rsvps '''
 
     if brigadeid:
-        if not cfapi.is_existing_organization(brigadeid):
+        brigade = cfapi.find_brigade(brigadeid)
+        if not brigade:
             return render_template('404.html'), 404
+        elif brigade["id"] != brigadeid:
+            return redirect(url_for("brigade.rsvps", brigadeid=brigade["id"]))
 
     if not brigadeid:
         got = get(cfapi.BASE_URL + "/events/rsvps")
@@ -218,12 +224,11 @@ def code_of_conduct():
 def brigade(brigadeid):
     ''' Get this Brigade's info '''
 
-    if brigadeid:
-        if not cfapi.is_existing_organization(brigadeid):
-            return render_template('404.html'), 404
-
-    got = get(cfapi.BASE_URL + "/organizations/" + brigadeid)
-    brigade = got.json()
+    brigade = cfapi.find_brigade(brigadeid)
+    if not brigade:
+        return render_template('404.html'), 404
+    elif brigade["id"] != brigadeid:
+        return redirect(url_for("brigade.brigade", brigadeid=brigade["id"]))
 
     ''' If Brigade has upcoming events, check if the next event is happening today '''
     if 'current_events' in brigade and len(brigade['current_events']) > 0:

--- a/cfapi/__init__.py
+++ b/cfapi/__init__.py
@@ -131,8 +131,20 @@ def get_projects(projects, url, limit=10):
     return projects
 
 
-def is_existing_organization(orgid):
+def brigade_has_old_name(org, old_name):
+    if not org["properties"].get("previous_names"):
+        return False
+
+    return old_name in org["properties"]["previous_names"]
+
+def find_brigade(orgid):
     ''' tests that an organization exists on the cfapi'''
     got = get(BASE_URL + "/organizations.geojson").json()
-    orgids = [org["properties"]["id"] for org in got["features"]]
-    return orgid in orgids
+    existing_brigade = next(iter(filter(lambda org: org["properties"]["id"] == orgid, got["features"])), None)
+    if existing_brigade:
+        return existing_brigade["properties"]
+
+    old_name = orgid.replace("-", " ")
+    renamed_brigade = next(iter(filter(lambda org: brigade_has_old_name(org, old_name), got["features"])), None)
+    if renamed_brigade:
+        return renamed_brigade["properties"]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,7 +33,7 @@ class BrigadeTests(unittest.TestCase):
         if url.geturl() == cfapi.BASE_URL + '/organizations/404':
             return httmock.response(404, '{"status": "Resource Not Found"}')
         if url.geturl() == cfapi.BASE_URL + '/organizations/TEST-ORG':
-            return httmock.response(200, '{"city": "San Francisco, CA", "type": "Brigade", "name": "Code for San Francisco"}') # noqa
+            return httmock.response(200, '{"city": "San Francisco, CA", "type": "Brigade", "name": "Code for San Francisco","social_profiles":{}}') # noqa
         if url.geturl() == cfapi.BASE_URL + "/organizations.geojson":
             return httmock.response(200, '''
                 {
@@ -44,7 +44,8 @@ class BrigadeTests(unittest.TestCase):
                             "name": "Test Org",
                             "tags": ["Brigade", "Official", "Code for America"], 
                             "last_updated": 1510874211,
-                            "city": "Oakland, CA"
+                            "city": "Oakland, CA",
+                            "social_profiles":{}
                         } 
                     },
                     { 


### PR DESCRIPTION
This will prevent discontinuity in Google Search results, etc., when a
Brigade renames.