### PR TITLE
Rename and rearrange Events page, and add copy

### DIFF
--- a/brigade/templates/base.html
+++ b/brigade/templates/base.html
@@ -54,7 +54,7 @@
               <nav class="bar-menu global-header-menu align-left" role="navigation">
                 {{ nav_link('brigade.about', 'About Us', class_name='menu-item', active_class_name='active-menu-item') }}
                 {{ nav_link('brigade.brigade_list', 'Find a Brigade', class_name='menu-item', active_class_name='active-menu-item') }}
-                {{ nav_link('brigade.events', 'Events', class_name='menu-item', active_class_name='active-menu-item') }}
+                {{ nav_link('brigade.events', 'Brigade Calendar', class_name='menu-item', active_class_name='active-menu-item') }}
                 {{ nav_link('brigade.priority_action_areas', 'Priority Action Areas', class_name='menu-item', active_class_name='active-menu-item') }}
               </nav>
 

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Events Calendar{% endblock %}
+{% block title %}Brigade Calendar{% endblock %}
 {% block description %}Events happening across the Code for America Brigade Network{% endblock %}
-{% block subhero_title %}Events{% endblock %}
+{% block subhero_title %}Brigade Calendar{% endblock %}
 {% block subhero_description %}
 <p class="lead-in-text">Events happening across the Code for America Brigade Network</p>
 {% endblock %}
@@ -9,8 +9,8 @@
 {% block in_page_nav %}
 <nav>
   <strong>On this page:</strong>
-  <a href="#key-dates" class="in-page-nav__link">Key Dates</a>
   <a href="#workshops-and-meetings" class="in-page-nav__link">Workshops and Meetings</a>
+  <a href="#key-dates" class="in-page-nav__link">Key Dates</a>
 </nav>
 {% endblock %}
 {% block hero_right %}
@@ -25,61 +25,6 @@
 {% endblock %}
 
 {% block content %}
-<section id="key-dates" class="slab slab--compact">
-  <div class="grid-box">
-    <div class="width-one-half">
-
-      <h2 class="slab__title">Key Dates</h2>
-
-      <p class="slab__subtitle">Brigades have an opportunity to participate in days of action and to come together at shared events. Check out the upcoming events and mark your calendar!</p>
-
-      <ul class="list list--no-bullets list--expanded">
-        <li>
-          <h3><small>March 7, 2020</small> <br>
-            <a href="https://opendataday.org/" target="_blank"><strong>Open Data Day</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
-          </h3>
-          <p>Many brigades participate in Open Data Day, an annual celebration of open data all over the world. It is an opportunity to showcase the benefits of civic technology and encourage the adoption of open data policies in government, business and civil society.</p>
-
-          <p><strong>Organizer resource:</strong> <a href="https://medium.com/code-for-america/open-data-day-planning-workshop-38ad9f82cab" target="_blank">Getting Ready for Open Data Day 2018</a></p>
-
-          </p>
-        </li>
-        <li>
-          <h3>
-            <small>March 11-13, 2020</small> <br>
-            <a href="https://www.codeforamerica.org/summit" target="_blank"><strong>Code for America Summit</strong></a>
-          </h3>
-          <p>
-          Our annual three-day event is an opportunity for public servants, advocates, entrepreneurs, technologists, and volunteers to get together in one room and break through some of government’s biggest challenges. In 2020, the Code for America Summit will be in <strong>Washington, D.C.</strong> and will feature content in four focus areas: Design + Delivery; Civic Innovation + Data; Operations + Management; and Technology + Policy.
-          </p>
-        </li>
-        <li>
-          <h3>
-            <small>September 12, 2020</small> <br>
-
-            <a href="https://www.codeforamerica.org/events/national-day-of-civic-hacking" target="_blank"><strong>National Day of Civic Hacking</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
-          </h3>
-          <p>
-            This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the digital age if we all build it together.
-          </p>
-        </li>
-
-        <li>
-          <h3><small>October 16–18, 2020</small><br>
-            <a href="https://www.codeforamerica.org/brigade-congress" target="_blank"><strong>Brigade Congress</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
-          </h3>
-          <p>
-            Brigade Congress is the primary in-person meeting centered on the Code for America Network, bringing together Brigade leaders, government and community partners, and civic tech professionals from across the country.
-          </p>
-          <p>
-            Due to COVID-19, Brigade Congress 2020 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
-          </p>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-
 <section id="workshops-and-meetings" class="slab gray-bg-slab">
   <div class="grid-box">
     <div class="width-one-half">
@@ -104,4 +49,48 @@
   </div>
 </section>
 
+<section id="key-dates" class="slab">
+  <div class="grid-box">
+    <div class="width-one-half">
+
+      <h2 class="slab__title">Key Dates</h2>
+
+      <p class="slab__subtitle">Brigades have an opportunity to participate in days of action and to come together at shared events. Check out the upcoming events and mark your calendar!</p>
+      <h3>
+        <small>May 12–13, 2021</small> <br>
+        <a href="https://www.codeforamerica.org/summit" target="_blank"><strong>Code for America Summit</strong></a>
+      </h3>
+      <p>
+        The Code for America Summit is a two-day virtual experience that brings changemakers into one room―public servants, advocates, technologists, and organizers break through some of the governments’ biggest challenges by removing barriers and expanding government access to serve all Americans. Summit offers dozens of keynotes, breakout sessions, and workshops. For 2021, Summit will focus on four tracks: Design + Delivery; Civic Innovation + Data; Operations + Management; and Technology + Policy.
+      </p>
+      <h3>
+        <small>September 12, 2020</small> <br>
+        <a href="https://www.codeforamerica.org/events/national-day-of-civic-hacking" target="_blank"><strong>National Day of Civic Hacking</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
+      </h3>
+      <p>
+        This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the digital age if we all build it together.
+      </p>
+      <h3><small>October 16–18, 2020</small><br>
+        <a href="https://www.codeforamerica.org/brigade-congress" target="_blank"><strong>Brigade Congress</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
+      </h3>
+      <p>
+        Brigade Congress is the primary in-person meeting centered on the Code for America Network, bringing together Brigade leaders, government and community partners, and civic tech professionals from across the country.
+      </p>
+      <p>
+        Due to COVID-19, Brigade Congress 2020 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
+      </p>
+      <p>
+        <br>
+      </p>
+      <div class="message">
+        <div class="message__icon">
+          <i class="fas fa-question-circle"></i>
+        </div>
+        <div class="message__content">
+          <strong>Are you a Brigade leader and want to know important dates for 2021?</strong> <br> <a href="https://discourse.codeforamerica.org/t/brigade-network-calendar/1005">View the Brigade Network Calendar on Discourse</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -25,6 +25,16 @@
 {% endblock %}
 
 {% block content %}
+<div class="grid-box">
+  <div class="message">
+    <div class="message__icon">
+      <i class="fas fa-question-circle"></i>
+    </div>
+    <div class="message__content">
+      <strong>Are you a Brigade leader and want to know important dates for 2021?</strong> <br> <a href="https://discourse.codeforamerica.org/t/brigade-network-calendar/1005">View the Brigade Network Calendar on Discourse</a>
+    </div>
+  </div>
+</div>
 <section id="workshops-and-meetings" class="slab gray-bg-slab">
   <div class="grid-box">
     <div class="width-one-half">
@@ -64,13 +74,13 @@
         The Code for America Summit is a two-day virtual experience that brings changemakers into one room―public servants, advocates, technologists, and organizers break through some of the governments’ biggest challenges by removing barriers and expanding government access to serve all Americans. Summit offers dozens of keynotes, breakout sessions, and workshops. For 2021, Summit will focus on four tracks: Design + Delivery; Civic Innovation + Data; Operations + Management; and Technology + Policy.
       </p>
       <h3>
-        <small>September 12, 2020</small> <br>
+        <small>September 18, 2021</small> <br>
         <a href="https://www.codeforamerica.org/events/national-day-of-civic-hacking" target="_blank"><strong>National Day of Civic Hacking</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
       </h3>
       <p>
         This annual event brings together public servants, people with technology skills, and community organizers, to show that government can work in the digital age if we all build it together.
       </p>
-      <h3><small>October 16–18, 2020</small><br>
+      <h3><small>October 15–17, 2021</small><br>
         <a href="https://www.codeforamerica.org/brigade-congress" target="_blank"><strong>Brigade Congress</strong> <i class="fas fa-external-link-alt fa-xs"></i></a>
       </h3>
       <p>
@@ -79,17 +89,6 @@
       <p>
         Due to COVID-19, Brigade Congress 2020 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
       </p>
-      <p>
-        <br>
-      </p>
-      <div class="message">
-        <div class="message__icon">
-          <i class="fas fa-question-circle"></i>
-        </div>
-        <div class="message__content">
-          <strong>Are you a Brigade leader and want to know important dates for 2021?</strong> <br> <a href="https://discourse.codeforamerica.org/t/brigade-network-calendar/1005">View the Brigade Network Calendar on Discourse</a>
-        </div>
-      </div>
     </div>
   </div>
 </section>

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -9,8 +9,8 @@
 {% block in_page_nav %}
 <nav>
   <strong>On this page:</strong>
-  <a href="#workshops-and-meetings" class="in-page-nav__link">Workshops and Meetings</a>
   <a href="#key-dates" class="in-page-nav__link">Key Dates</a>
+  <a href="#workshops-and-meetings" class="in-page-nav__link">Workshops and Meetings</a>
 </nav>
 {% endblock %}
 {% block hero_right %}
@@ -26,45 +26,23 @@
 
 {% block content %}
 <div class="grid-box">
-  <div class="message">
-    <div class="message__icon">
-      <i class="fas fa-question-circle"></i>
-    </div>
-    <div class="message__content">
-      <strong>Are you a Brigade leader and want to know important dates for 2021?</strong> <br> <a href="https://discourse.codeforamerica.org/t/brigade-network-calendar/1005">View the Brigade Network Calendar on Discourse</a>
+  <div class="span-eight">
+    <div class="message">
+      <div class="message__icon">
+        <i class="fas fa-info-circle"></i>
+      </div>
+      <div class="message__content">
+        <strong>Members of the Brigade Network can help shape our future by participating in planning committees and working groups.</strong> <a href="https://discourse.codeforamerica.org/t/key-2021-participation-dates/1005">View key 2021 participation dates on Discourse</a>
+      </div>
     </div>
   </div>
 </div>
-<section id="workshops-and-meetings" class="slab gray-bg-slab">
-  <div class="grid-box">
-    <div class="width-one-half">
-      <h2 class="slab__title">Workshops and Meetings</h2>
-      <ul>
-        <li>Code for America is helping build a network of civic technologists eager to share ideas and collaborate nationwide.</li>
-        <li>We host events like workshops, forums and meetings, to share knowledge, experiences and lessons learned.</li>
-        <li>All brigade members are encouraged to attend these events. To participate, check out the attached calendar.</li>
-      </ul>
-      <div class="message">
-        <div class="message__icon">
-          <i class="fas fa-question-circle"></i>
-        </div>
-        <div class="message__content">
-          <strong>Have a meeting or workshop to add to the calendar?</strong> <br>Let us know at <a href="mailto:brigade-info@codeforamerica.org">brigade-info@codeforamerica.org</a>
-        </div>
-      </div>
-    </div>
-    <div class="width-one-half">
-      <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=codeforamerica.org_e4fugvnjpk4b5fvgjfe916sa6g%40group.calendar.google.com&amp;color=%23182C57&amp;ctz=America%2FLos_Angeles" style="border:solid 1px #777" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
-    </div>
-  </div>
-</section>
 
-<section id="key-dates" class="slab">
-  <div class="grid-box">
-    <div class="width-one-half">
-
+<div class="grid-box">
+  <div class="span-five">
+    <section id="key-dates" class="slab">
       <h2 class="slab__title">Key Dates</h2>
-
+    
       <p class="slab__subtitle">Brigades have an opportunity to participate in days of action and to come together at shared events. Check out the upcoming events and mark your calendar!</p>
       <h3>
         <small>May 12–13, 2021</small> <br>
@@ -89,7 +67,26 @@
       <p>
         Due to COVID-19, Brigade Congress 2021 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
       </p>
-    </div>
+    </section>
   </div>
-</section>
+  <div class="span-five shift-two">
+    <section id="workshops-and-meetings" class="slab">
+      <h2 class="slab__title">Workshops and Meetings</h2>
+      <ul>
+        <li>Code for America is helping build a network of civic technologists eager to share ideas and collaborate nationwide.</li>
+        <li>We host events like workshops, forums and meetings, to share knowledge, experiences and lessons learned.</li>
+        <li>All brigade members are encouraged to attend these events. To participate, check out the attached calendar.</li>
+      </ul>
+      <div class="message">
+        <div class="message__icon">
+          <i class="fas fa-question-circle"></i>
+        </div>
+        <div class="message__content">
+          <strong>Have a meeting or workshop to add to the calendar?</strong> <br>Let us know at <a href="mailto:brigade-info@codeforamerica.org">brigade-info@codeforamerica.org</a>
+        </div>
+      </div>
+      <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=codeforamerica.org_e4fugvnjpk4b5fvgjfe916sa6g%40group.calendar.google.com&amp;color=%23182C57&amp;ctz=America%2FLos_Angeles" style="border:solid 1px #777" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
+    </section>
+  </div>
+</div>
 {% endblock %}

--- a/brigade/templates/events.html
+++ b/brigade/templates/events.html
@@ -87,7 +87,7 @@
         Brigade Congress is the primary in-person meeting centered on the Code for America Network, bringing together Brigade leaders, government and community partners, and civic tech professionals from across the country.
       </p>
       <p>
-        Due to COVID-19, Brigade Congress 2020 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
+        Due to COVID-19, Brigade Congress 2021 will be held online. More details will be posted to <a href="https://www.codeforamerica.org/brigade-congress">the event's web page</a> as the date approaches.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This relates to a request from Em Burnett, Sr. Manager of Network Communications.

- Renaming "Events" page -> "Brigade calendar"
- Removing Open Data Day as a key event
- Add message to bottom for Brigade leaders to check Discourse for important dates
- Rearrange section structure, so that Workshops+Meetings calendar is first section, and Key Dates is second